### PR TITLE
Add type option to v-button

### DIFF
--- a/src/elements/button.svelte
+++ b/src/elements/button.svelte
@@ -8,6 +8,7 @@ import { addStyles } from '../lib/index'
 type Variants = 'primary' | 'danger' | 'outline-danger' | 'success'
 
 export let disabled: 'true' | 'false' = 'false'
+export let type: 'button' | 'submit' | 'reset' = 'button'
 export let variant: Variants = 'primary'
 export let label = ''
 export let icon = ''
@@ -17,7 +18,7 @@ addStyles()
 </script>
 
 <button
-  type='button'
+  type={type}
   class={cx('flex items-center gap-1.5 py-1.5 px-2 text-xs border', {
     'cursor-not-allowed opacity-50 pointer-events-none': disabled === 'true',
     'bg-white border-black': variant === 'primary',

--- a/src/stories/button.stories.mdx
+++ b/src/stories/button.stories.mdx
@@ -18,6 +18,12 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs'
       options: ['primary', 'success', 'danger', 'outline-danger'],
       table: { defaultValue: { summary: 'primary' } }
     },
+    type: {
+      description: 'The type attribute for the button',
+      control: 'select',
+      options: [ 'button', 'submit', 'reset'],
+      table: { defaultValue: { summary: 'button' } }
+    },
   }}
 />
 


### PR DESCRIPTION
Add an optional `type` property to `<v-button />` so it can be used as `submit` and `reset` buttons.