### PR TITLE
specify license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.53",
+  "version": "0.0.54",
+  "license": "MIT",
   "type": "commonjs",
   "files": [
     "dist"


### PR DESCRIPTION
a bit of a silly change... I want to see if this helps our license finder tool detect the license for this package (https://github.com/viamrobotics/rdk/pull/1178)