### PR TITLE
Add tooltip to v-switch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "license": "Apache-2.0",
   "type": "commonjs",
   "files": [

--- a/src/elements/switch.svelte
+++ b/src/elements/switch.svelte
@@ -12,6 +12,7 @@ export let value: 'on' | 'off' = 'off';
 export let variant: 'annotated' | 'default' = 'default';
 export let disabled: string | undefined;
 export let labelposition: 'left' | 'top' = 'top';
+export let tooltip = '';
 
 addStyles();
 
@@ -39,6 +40,7 @@ const handleClick = () => {
     'opacity-50 pointer-events-none': isDisabled,
   })}
 >
+<div class='flex items-center gap-1.5'>
   {#if label}
     <p class={cx('text-xs capitalize', {
       'whitespace-nowrap': labelposition === 'left',
@@ -46,6 +48,14 @@ const handleClick = () => {
       {label}
     </p>
   {/if}
+
+  {#if tooltip}
+  <v-tooltip text={tooltip}>
+    <div class="icon-info-outline text-black" />
+  </v-tooltip>
+  {/if}
+</div>
+  
 
   <button
     on:click={handleClick}

--- a/src/stories/switch.stories.mdx
+++ b/src/stories/switch.stories.mdx
@@ -31,7 +31,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs'
       table: { defaultValue: { summary: 'false' } }
     },
       tooltip: {
-      description: 'The tooltip mesage.',
+      description: 'The tooltip message.',
     },
     'on:input': {
       description: 'Event fired when input value changes.',

--- a/src/stories/switch.stories.mdx
+++ b/src/stories/switch.stories.mdx
@@ -30,6 +30,9 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs'
       options: ['true', 'false'],
       table: { defaultValue: { summary: 'false' } }
     },
+      tooltip: {
+      description: 'The tooltip mesage.',
+    },
     'on:input': {
       description: 'Event fired when input value changes.',
     },
@@ -103,6 +106,27 @@ Used to handle binary input.
         value='${value}'
         variant='${variant}'
         disabled='${disabled}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Tooltip'
+    args={{
+      value: 'off',
+      variant: 'labeled',
+      label: 'Switch Label',
+      tooltip: 'This is the tooltip message.'
+    }}
+  >
+    {({ value, variant, tooltip, label }) => `
+      <v-switch
+        value='${value}'
+        variant='${variant}'
+        tooltip='${tooltip}'
+        label='${label}'
       />
     `}
   </Story>


### PR DESCRIPTION
**20221024_Add tooltip to v-switch**

**Items to Note:**

- This PR adds a tooltip to the v-switch PRIME element.
- I need this for the remotes tab in app.

<img width="1124" alt="Screen Shot 2022-10-24 at 1 32 39 PM" src="https://user-images.githubusercontent.com/83609116/197589492-607b75db-2227-4939-b244-80ca71adcad7.png">
