### PR TITLE
prevents v-button from being invoked when disabled

### DIFF
--- a/src/elements/button/button.svelte
+++ b/src/elements/button/button.svelte
@@ -12,7 +12,7 @@ import cx from 'classnames';
 import { get_current_component } from 'svelte/internal';
 import { htmlToBoolean } from '../../lib/boolean';
 import { addStyles } from '../../lib/index';
-import { dispatcher } from '../../lib/dispatch';
+import { dispatcherWithEventPassThrough } from '../../lib/dispatch';
 
 export let disabled = 'false';
 export let type: 'button' | 'submit' | 'reset' = 'button';
@@ -32,7 +32,7 @@ $: isDisabled = htmlToBoolean(disabled, 'disabled');
 // @TODO switch to <svelte:this bind:this={component}> https://github.com/sveltejs/rfcs/pull/58
 const component = get_current_component() as HTMLElement & { internals: ElementInternals };
 const internals = component.attachInternals();
-const dispatch = dispatcher();
+const dispatch = dispatcherWithEventPassThrough();
 
 const handleClick = () => {
   const { form } = internals;
@@ -47,7 +47,7 @@ const handleClick = () => {
 const handleParentClick = (e) => {
   e.stopImmediatePropagation();
   if (!isDisabled) {
-    dispatch('click', e)
+    dispatch<PointerEvent>('click', e)
   }
 }
 

--- a/src/elements/button/button.svelte
+++ b/src/elements/button/button.svelte
@@ -44,12 +44,12 @@ const handleClick = () => {
   }
 };
 
-const handleParentClick = (e) => {
+const handleParentClick = (e: PointerEvent) => {
   e.stopImmediatePropagation();
   if (!isDisabled) {
-    dispatch<PointerEvent>('click', e)
+    dispatch<PointerEvent>('click', e);
   }
-}
+};
 
 </script>
 

--- a/src/elements/button/button.svelte
+++ b/src/elements/button/button.svelte
@@ -12,7 +12,6 @@ import cx from 'classnames';
 import { get_current_component } from 'svelte/internal';
 import { htmlToBoolean } from '../../lib/boolean';
 import { addStyles } from '../../lib/index';
-import { dispatcherWithEventPassThrough } from '../../lib/dispatch';
 
 export let disabled = 'false';
 export let type: 'button' | 'submit' | 'reset' = 'button';
@@ -32,7 +31,6 @@ $: isDisabled = htmlToBoolean(disabled, 'disabled');
 // @TODO switch to <svelte:this bind:this={component}> https://github.com/sveltejs/rfcs/pull/58
 const component = get_current_component() as HTMLElement & { internals: ElementInternals };
 const internals = component.attachInternals();
-const dispatch = dispatcherWithEventPassThrough();
 
 const handleClick = () => {
   const { form } = internals;
@@ -45,9 +43,8 @@ const handleClick = () => {
 };
 
 const handleParentClick = (e: PointerEvent) => {
-  e.stopImmediatePropagation();
-  if (!isDisabled) {
-    dispatch<PointerEvent>('click', e);
+  if (isDisabled) {
+    e.stopImmediatePropagation();
   }
 };
 

--- a/src/elements/button/button.svelte
+++ b/src/elements/button/button.svelte
@@ -12,6 +12,7 @@ import cx from 'classnames';
 import { get_current_component } from 'svelte/internal';
 import { htmlToBoolean } from '../../lib/boolean';
 import { addStyles } from '../../lib/index';
+import { dispatcher } from '../../lib/dispatch';
 
 export let disabled = 'false';
 export let type: 'button' | 'submit' | 'reset' = 'button';
@@ -31,6 +32,7 @@ $: isDisabled = htmlToBoolean(disabled, 'disabled');
 // @TODO switch to <svelte:this bind:this={component}> https://github.com/sveltejs/rfcs/pull/58
 const component = get_current_component() as HTMLElement & { internals: ElementInternals };
 const internals = component.attachInternals();
+const dispatch = dispatcher();
 
 const handleClick = () => {
   const { form } = internals;
@@ -42,6 +44,13 @@ const handleClick = () => {
   }
 };
 
+const handleParentClick = (e) => {
+  e.stopImmediatePropagation();
+  if (!isDisabled) {
+    dispatch('click', e)
+  }
+}
+
 </script>
 
 <style>
@@ -51,6 +60,7 @@ const handleClick = () => {
 <svelte:element
   this={tooltip ? 'v-tooltip' : 'span'}
   text={tooltip}
+  on:click={handleParentClick}
 >
   <button
     {type}

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -10,4 +10,3 @@ export const dispatcher = () => {
     detail,
   }));
 };
-

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -14,7 +14,6 @@ export const dispatcher = () => {
 
 export const dispatcherWithEventPassThrough = () => {
   const element = get_current_component() as HTMLElement;
-  // eslint-disable-next-line no-prototype-builtins
   return <EventType extends Event>(name: string, event: EventType) => {
     const copyEvent = new Proxy(event, 
       { get: (target: object, prop: keyof object) => prop === 'composed' || prop === 'bubbles' ? true : target[prop] }

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -11,15 +11,3 @@ export const dispatcher = () => {
   }));
 };
 
-
-export const dispatcherWithEventPassThrough = () => {
-  const element = get_current_component() as HTMLElement;
-  return <EventType extends Event>(name: string, event: EventType) => {
-    const copyEvent = new Proxy(event, 
-      { get: (target: object, prop: keyof object) => prop === 'composed' || prop === 'bubbles' ? true : target[prop] }
-    );
-
-    const Constructor = event.constructor as unknown as typeof Event;
-    return element.dispatchEvent(new Constructor(name, copyEvent));
-  };
-};

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -4,13 +4,11 @@ import { get_current_component } from 'svelte/internal';
 export const dispatcher = () => {
   const element = get_current_component() as HTMLElement;
 
-  return (name: string, detail?: object) => {
-    return element.dispatchEvent(new CustomEvent(name, {
-      composed: true,
-      bubbles: true,
-      detail,
-    }));
-  };
+  return (name: string, detail?: object) => element.dispatchEvent(new CustomEvent(name, {
+    composed: true,
+    bubbles: true,
+    detail,
+  }));
 };
 
 
@@ -22,7 +20,7 @@ export const dispatcherWithEventPassThrough = () => {
       { get: (target: object, prop: keyof object) => prop === 'composed' || prop === 'bubbles' ? true : target[prop] }
     );
 
-    const Constructor = event.constructor as unknown as typeof Event
+    const Constructor = event.constructor as unknown as typeof Event;
     return element.dispatchEvent(new Constructor(name, copyEvent));
   };
 };

--- a/src/lib/dispatch.ts
+++ b/src/lib/dispatch.ts
@@ -4,9 +4,25 @@ import { get_current_component } from 'svelte/internal';
 export const dispatcher = () => {
   const element = get_current_component() as HTMLElement;
 
-  return (name: string, detail?: object) => element.dispatchEvent(new CustomEvent(name, {
-    composed: true,
-    bubbles: true,
-    detail,
-  }));
+  return (name: string, detail?: object) => {
+    return element.dispatchEvent(new CustomEvent(name, {
+      composed: true,
+      bubbles: true,
+      detail,
+    }));
+  };
+};
+
+
+export const dispatcherWithEventPassThrough = () => {
+  const element = get_current_component() as HTMLElement;
+  // eslint-disable-next-line no-prototype-builtins
+  return <EventType extends Event>(name: string, event: EventType) => {
+    const copyEvent = new Proxy(event, 
+      { get: (target: object, prop: keyof object) => prop === 'composed' || prop === 'bubbles' ? true : target[prop] }
+    );
+
+    const Constructor = event.constructor as unknown as typeof Event
+    return element.dispatchEvent(new Constructor(name, copyEvent));
+  };
 };


### PR DESCRIPTION
Adds a click handler to the v-button that prevents the click handler attached at point of implementation from being invoked. `stopImmediatePropagation` stops event handlers of the same type added after from being invoked - can then choose to dispatch (proceeding with the propagation) if the input is not disabled. Also adds a new dispatcher that copies the dispatch event, allowing the event to pass through as the correct type.