### PR TITLE
[DATA-804] add reduce sort to select, split out multi-select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.88",
+      "version": "0.0.89",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.19.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.89",
+  "version": "0.0.90",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.89",
+      "version": "0.0.90",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.88",
+  "version": "0.0.90",
   "license": "Apache-2.0",
   "type": "commonjs",
   "files": [

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -99,6 +99,7 @@ setTimeout(() => {
       withbutton="true"
       buttontext="hello"
       buttonicon="x"
+      heading="heading title"
     />
 
     <v-collapse class="p-3" title='Hello world?'>

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -91,12 +91,16 @@ setTimeout(() => {
 
     <Monaco />
 
-    <v-select 
-      options="ab, bc, cd, dz, e24gsdg, f dskfm 3??"
-      value="a"
-      variant="multiple"
+    <v-multiselect 
+      options="ab, bc, cd, dz, e24gsdg, f dskfm 3??, abs, abd, ac, ad, adb"
+      value="ab, cd"
+      reducesort="true"
       dosearch="true"
+      withbutton="true"
+      buttontext="hello"
+      buttonicon="x"
     />
+
     <v-collapse class="p-3" title='Hello world?'>
       Hello world
     </v-collapse>

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -94,8 +94,7 @@ setTimeout(() => {
     <v-multiselect 
       options="ab, bc, cd, dz, e24gsdg, f dskfm 3??, abs, abd, ac, ad, adb"
       value="ab, cd"
-      reducesort="true"
-      dosearch="true"
+      sortoption="reduce"
       withbutton="true"
       buttontext="hello"
       buttonicon="x"

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -91,6 +91,12 @@ setTimeout(() => {
 
     <Monaco />
 
+    <v-select 
+      options="ab, bc, cd, dz, e24gsdg, f dskfm 3??"
+      value="a"
+      variant="multiple"
+      dosearch="true"
+    />
     <v-collapse class="p-3" title='Hello world?'>
       Hello world
     </v-collapse>

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -316,11 +316,13 @@ $: {
           class='flex max-h-36 flex-col'
           on:mouseleave={clearNavigationIndex}
         >
-          <span
-            class='flex text-xs text-gray-500 pl-2 pt-2 flex-wrap'
-          >
-            {heading}
-          </span>
+          {#if heading}
+            <span
+              class='flex text-xs text-gray-500 pl-2 pt-2 flex-wrap'
+            >
+              {heading}
+            </span>
+          {/if}
           {#each searchedOptions as { search, option }, index (option)}
             <label
               class={cx('flex w-full gap-2 text-ellipsis whitespace-nowrap px-2 py-1.5 text-xs', {

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -10,7 +10,6 @@ import { searchSort } from '../../lib/sort';
 import { htmlToBoolean } from '../../lib/boolean';
 import { addStyles } from '../../lib/index';
 import { dispatcher } from '../../lib/dispatch';
-import SelectButton from './select-button.svelte';
 import * as utils from './utils';
 
 export let options = '';
@@ -77,7 +76,7 @@ const setKeyboardControl = (toggle: boolean) => {
 };
 
 const applySearchSort = (term: string, options: string[]) => {
-  if (options[0] === '' && options.length === 1){
+  if (options[0] === '' && options.length === 1) {
     return [];
   }
   dispatch('search', { term });
@@ -392,10 +391,11 @@ $: {
       {/if}
       </div>
       {#if hasButton}
-        <SelectButton
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <v-select-button
           buttontext={buttontext}
           buttonicon={buttonicon}
-          on:button-click={handleButtonClick}
+          on:click={handleButtonClick}
         />
       {/if}
 

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -19,7 +19,6 @@ export let placeholder = '';
 export let label = '';
 export let labelposition: LabelPosition = 'top';
 export let disabled = 'false';
-export let exact = 'false';
 export let prefix = 'false';
 export let tooltip = '';
 export let state: 'info' | 'warn' | 'error' | '' = 'info';
@@ -39,13 +38,12 @@ let root: HTMLElement;
 let input: HTMLInputElement;
 let optionsContainer: HTMLElement;
 let isDisabled: boolean;
-let isExact: boolean;
 let hasPrefix: boolean;
 let showsPill: boolean;
 let canClearAll: boolean;
 let hasButton: boolean;
 let isReduceSort: boolean;
-let doesSearch: boolean
+let doesSearch: boolean;
 let parsedOptions: string[];
 let parsedSelected: string[];
 let sortedOptions: string[];
@@ -54,7 +52,6 @@ let searchedOptions: { option: string; search?: string[] }[];
 let searchTerm = '';
 
 $: isDisabled = htmlToBoolean(disabled, 'disabled');
-$: isExact = htmlToBoolean(exact, 'exact');
 $: hasPrefix = htmlToBoolean(prefix, 'prefix');
 $: showsPill = htmlToBoolean(showpill, 'showpill');
 $: canClearAll = htmlToBoolean(clearable, 'clearable');
@@ -65,7 +62,7 @@ $: parsedOptions = options.split(',').map((str) => str.trim());
 $: parsedSelected = value.split(',').filter(Boolean).map((str) => str.trim());
 $: sortedOptions = doesSearch ? applySearchSort(searchTerm, parsedOptions) : parsedOptions;
 $: searchedOptions = doesSearch ? utils.applySearchHighlight(sortedOptions, searchTerm) : 
-utils.applySearchHighlight(sortedOptions, '');
+  utils.applySearchHighlight(sortedOptions, '');
 
 let open = false;
 let navigationIndex = -1;
@@ -74,15 +71,12 @@ let keyboardControlling = false;
 let optionMatch = false;
 let optionMatchText = '';
 
-console.log('check withbutton:', withbutton);
-console.log('check hasButton:', hasButton);
-
 const setKeyboardControl = (toggle: boolean) => {
   keyboardControlling = toggle;
 };
 
 const applySearchSort = (term: string, options: string[]) => {
-  dispatch('search', { term })
+  dispatch('search', { term });
   return term ? searchSort(options, term, isReduceSort) : options;
 };
 
@@ -227,10 +221,6 @@ const splitOptionOnWord = (option: string) => {
 $: {
   if (!open) {
     searchTerm = '';
-
-    if (isExact && parsedOptions.includes(value) === false) {
-      value = '';
-    }
   }
 }
 
@@ -315,14 +305,14 @@ $: {
       {/if}
     </div>
 
-    <div 
+    <div  
       slot='content'
       class='mt-1 border border-black bg-white drop-shadow-md'
     >
+      <div bind:this={optionsContainer} class="options-container overflow-y-auto">
       {#if sortedOptions.length > 0}
         <div
-          bind:this={optionsContainer}
-          class='options-container flex max-h-36 flex-col overflow-y-auto'
+          class='flex max-h-36 flex-col'
           on:mouseleave={clearNavigationIndex}
         >
           {#each searchedOptions as { search, option }, index (option)}
@@ -389,6 +379,7 @@ $: {
           No matching results
         </div>
       {/if}
+      </div>
       {#if hasButton}
         <SelectButton
           buttontext={buttontext}

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -29,6 +29,7 @@ export let buttontext = 'ENTER';
 export let buttonicon = '';
 export let reducesort = 'false';
 export let dosearch = 'true';
+export let heading = '';
 
 const dispatch = dispatcher();
 
@@ -315,6 +316,11 @@ $: {
           class='flex max-h-36 flex-col'
           on:mouseleave={clearNavigationIndex}
         >
+          <span
+            class='flex text-xs text-gray-500 pl-2 pt-2 flex-wrap'
+          >
+            {heading}
+          </span>
           {#each searchedOptions as { search, option }, index (option)}
             <label
               class={cx('flex w-full gap-2 text-ellipsis whitespace-nowrap px-2 py-1.5 text-xs', {

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -1,0 +1,491 @@
+<svelte:options immutable tag='v-select' />
+
+<script lang='ts'>
+
+type LabelPosition = 'top' | 'left'
+
+// This entire component is pretty hacked together and should be refactored. Maybe split multi / single select.
+import cx from 'classnames';
+import { searchSort } from '../../lib/sort';
+import { htmlToBoolean } from '../../lib/boolean';
+import { addStyles } from '../../lib/index';
+import { dispatcher } from '../../lib/dispatch';
+import * as utils from './utils';
+
+export let options = '';
+export let value = '';
+export let placeholder = '';
+export let label = '';
+export let labelposition: LabelPosition = 'top';
+export let disabled = 'false';
+export let exact = 'false';
+export let prefix = 'false';
+export let tooltip = '';
+export let state: 'info' | 'warn' | 'error' | '' = 'info';
+export let showpill = 'false';
+export let clearable = 'true';
+export let withbutton = 'false';
+export let buttontext = 'ENTER';
+export let buttonicon = '';
+export let reducesort = 'false';
+export let dosearch = 'true';
+
+const dispatch = dispatcher();
+
+addStyles();
+
+let root: HTMLElement;
+let input: HTMLInputElement;
+let optionsContainer: HTMLElement;
+
+let isDisabled: boolean;
+let isExact: boolean;
+let hasPrefix: boolean;
+let showsPill: boolean;
+let canClearAll: boolean;
+let hasButton: boolean;
+let isReduceSort: boolean;
+let doesSearch: boolean
+let parsedOptions: string[];
+let parsedSelected: string[];
+let sortedOptions: string[];
+let searchedOptions: { option: string; search?: string[] }[];
+
+let searchTerm = '';
+
+$: isDisabled = htmlToBoolean(disabled, 'disabled');
+$: isExact = htmlToBoolean(exact, 'exact');
+$: hasPrefix = htmlToBoolean(prefix, 'prefix');
+$: showsPill = htmlToBoolean(showpill, 'showpill');
+$: canClearAll = htmlToBoolean(clearable, 'clearable');
+$: hasButton = htmlToBoolean(withbutton, 'withbutton');
+$: isReduceSort = htmlToBoolean(reducesort, 'reducesort');
+$: doesSearch = htmlToBoolean(dosearch, 'dosearch');
+$: parsedOptions = options.split(',').map((str) => str.trim());
+$: parsedSelected = isMultiple
+  ? value.split(',').filter(Boolean).map((str) => str.trim())
+  : [];
+$: sortedOptions = determineSortedOptions(parsedOptions, doesSearch);
+$: searchedOptions = doesSearch ? (isMultiple ? 
+utils.applySearchHighlight(sortedOptions, searchTerm) : 
+utils.applySearchHighlight(sortedOptions, value)) :
+utils.applySearchHighlight(sortedOptions, '');
+
+let open = false;
+let navigationIndex = -1;
+let keyboardControlling = false;
+
+let optionMatch = false;
+let optionMatchText = '';
+
+const setKeyboardControl = (toggle: boolean) => {
+  keyboardControlling = toggle;
+};
+
+const applySearchSort = (term: string, options: string[]) => {
+  dispatch('search', { term })
+  return term ? searchSort(options, term, isReduceSort) : options;
+};
+
+const determineSortedOptions = (inputOptions: string[], search: boolean) => {
+  if (!search) {
+    return inputOptions;
+  }
+  if (isMultiple) {
+    return applySearchSort(searchTerm, inputOptions);
+  } else {
+    return applySearchSort(value, inputOptions);
+  }
+}
+
+// const transformToSearchedOptions = (sorted: string[], search: boolean, term: string) => {
+//   if (!search) {
+//     return utils.applySearchHighlight(sorted, '');
+//   }
+//   if (isMultiple) {
+//     return utils.applySearchHighlight(sorted, term);
+//   } else {
+//     return utils.applySearchHighlight(sorted, value);
+//   }
+// }
+
+const handleInput = (event: Event) => {
+  navigationIndex = -1;
+  optionsContainer.scrollTop = 0;
+  event.stopImmediatePropagation();
+  if (isMultiple) {
+    searchTerm = input.value.trim();
+    optionMatch = false;
+    for (const value of sortedOptions) {
+      if (searchTerm.toLowerCase() === value.toLowerCase()) {
+        optionMatch = true;
+        optionMatchText = value;
+      } 
+    }
+  } else {
+    value = input.value.trim();
+    dispatch('input', { value });
+  }
+};
+
+const handleKeyUp = (event: KeyboardEvent) => {
+  setKeyboardControl(true);
+
+  switch (event.key.toLowerCase()) {
+    case 'enter': return handleEnter();
+    case 'arrowup': return handleNavigate(-1);
+    case 'arrowdown': return handleNavigate(+1);
+    case 'escape': return handleEscape();
+  }
+};
+
+const handleEnter = () => {
+  if (isMultiple) {
+    const option = sortedOptions[navigationIndex]!;
+    value = value.includes(option)
+      ? [...parsedSelected.filter(item => item !== option)].toString()
+      : [...parsedSelected, option].toString();
+    input.focus();
+
+    if (optionMatch) {
+      if (value.includes(optionMatchText)) {
+        value = value.replace(`${optionMatchText},`, '');
+      } else {
+        value += `${optionMatchText},`;
+      }
+      searchTerm = '';
+      optionMatch = false;
+    }
+
+    dispatch('input', { value, values: value.split(',') });
+  } else {
+    if (navigationIndex > -1) {
+      value = sortedOptions[navigationIndex]!;
+    } else {
+      const result = sortedOptions.find(item => item.toLowerCase() === value);
+
+      if (result) {
+        value = result;
+      }
+    }
+    if (open) {
+      input.blur();
+    }
+
+    dispatch('input', { value });
+  }
+  
+};
+
+const handleNavigate = (direction: number) => {
+  navigationIndex += direction;
+
+  if (navigationIndex < 0) {
+    navigationIndex = sortedOptions.length - 1;
+  } else if (navigationIndex >= sortedOptions.length) {
+    navigationIndex = 0;
+  }
+
+  const element = optionsContainer.children[navigationIndex]!;
+
+  if (utils.isElementInScrollView(element) === false) {
+    element.scrollIntoView();
+  }
+};
+
+const clearNavigationIndex = () => {
+  navigationIndex = -1;
+};
+
+const handleEscape = () => {
+  input.blur();
+};
+
+const handleFocus = () => {
+  if (open || isDisabled) {
+    return;
+  }
+
+  open = true;
+  input.focus();
+};
+
+const handleFocusOut = (event: FocusEvent) => {
+  if (!root.contains(event.relatedTarget as Node)) {
+    open = false;
+    navigationIndex = -1;
+  }
+};
+
+const handleIconClick = () => {
+  if (!open) {
+    input.focus();
+  } else {
+    open = false;
+  }
+};
+
+const handlePillClick = (target: string) => {
+  value = [...parsedSelected.filter((item: string) => item !== target)].toString();
+  dispatch('input', { value, values: value.split(',') });
+  input.focus();
+};
+
+const handleOptionMouseEnter = (index: number) => {
+  if (keyboardControlling) {
+    return;
+  }
+
+  navigationIndex = index;
+};
+
+const handleOptionSelect = (target: string, event: Event) => {
+  const { checked } = (event.target as HTMLInputElement);
+
+  if (isMultiple === false && value === target) {
+    event.preventDefault();
+    open = false;
+    return;
+  }
+
+  value = checked
+    ? [...parsedSelected, target].toString()
+    : [...parsedSelected.filter((item: string) => item !== target)].toString();
+
+  if (isMultiple) {
+    input.focus();
+    if (checked) {
+      dispatch('input', { value, values: value.split(','), added: target });
+    } else {
+      dispatch('input', { value, values: value.split(','), removed: target });
+    }
+    
+  } else {
+    open = false;
+    dispatch('input', { value });
+  }
+};
+
+const handleClearAll = () => {
+  value = '';
+  optionsContainer.scrollTop = 0;
+  if (isMultiple) {
+    dispatch('input', { value, values: value.split(',') });
+  } else {
+    dispatch('input', { value });
+  }
+};
+
+const handleButtonClick = () => {
+  dispatch('button-click');
+};
+
+const splitOptionOnWord = (option: string) => {
+  return option.split(' ');
+};
+
+$: {
+  if (!open) {
+    if (isMultiple) {
+      searchTerm = '';
+    }
+
+    if (isExact && parsedOptions.includes(value) === false) {
+      value = '';
+    }
+  }
+}
+
+</script>
+
+<!-- svelte-ignore a11y-label-has-associated-control -->
+<label
+  bind:this={root}
+  class={cx('relative min-w-[6rem] w-full flex gap-1', {
+    'z-[100]': open,
+    'flex-col': labelposition === 'top',
+    'items-center': labelposition === 'left',
+  })}
+  tabindex='-1'
+  on:focusin={handleFocus}
+  on:focusout={handleFocusOut}
+  on:mousemove={() => setKeyboardControl(false)}
+>
+  <div class='flex items-center gap-1.5'>
+    {#if label}
+      <p class={cx('text-xs capitalize', {
+        'opacity-50 pointer-events-none': isDisabled,
+        'inline whitespace-nowrap': labelposition === 'left',
+      })}>
+        {label}
+      </p>
+    {/if}
+
+    {#if tooltip}
+      <v-tooltip text={tooltip}>
+        <div class={cx({
+          'icon-info-outline': state === 'info',
+          'icon-error-outline text-orange-400': state === 'warn',
+          'icon-error-outline text-red-600': state === 'error',
+        })} />
+      </v-tooltip>
+    {/if}
+  </div>
+
+  <v-dropdown
+    match
+    open={open ? '' : undefined}
+  >
+    <div
+      slot='target'
+      class={cx('w-full border border-black', {
+        'opacity-50 pointer-events-none bg-gray-200': isDisabled,
+      })}
+    >
+      <div class='flex'>
+        <input
+          bind:this={input}
+          {placeholder}
+          value={isMultiple ? searchTerm : value}
+          aria-disabled={isDisabled}
+          readonly={isDisabled}
+          type='text'
+          class='py-1.5 pl-2.5 pr-1 grow text-xs border-0 bg-white outline-none appearance-none'
+          on:input|preventDefault={handleInput}
+          on:keyup|stopPropagation|preventDefault={handleKeyUp}
+        >
+        <button
+          tabindex='-1'
+          aria-label='Open dropdown'
+          class={cx('py-1.5 px-1 grid place-content-center transition-transform duration-200', { 'rotate-180': open })}
+          on:click={handleIconClick}
+          on:focusin|stopPropagation
+        >
+          <v-icon class='flex' name='chevron-down' />
+        </button>
+      </div>
+
+      {#if parsedSelected.length > 0 && showsPill}
+        <div class='flex flex-wrap gap-2 p-1'>
+          {#each parsedSelected as option (option)}
+            <v-pill
+              on:remove={() => handlePillClick(option)}
+              value={option}
+            />
+          {/each}
+        </div>
+      {/if}
+    </div>
+
+    <div 
+      slot='content'
+      class='mt-1 border border-black bg-white drop-shadow-md'
+    >
+      {#if sortedOptions.length > 0}
+        <div
+          bind:this={optionsContainer}
+          class='options-container flex max-h-36 flex-col overflow-y-auto'
+          on:mouseleave={clearNavigationIndex}
+        >
+          {#each searchedOptions as { search, option }, index (option)}
+            <label
+              class={cx('flex w-full gap-2 text-ellipsis whitespace-nowrap px-2 py-1.5 text-xs', {
+                'bg-slate-200': navigationIndex === index,
+                'text-gray-500': hasPrefix,
+              })}
+              on:mouseenter={() => handleOptionMouseEnter(index)}
+            >
+              <input
+                tabindex="-1"
+                type='checkbox'
+                class={cx('bg-black outline-none', isMultiple ? '' : 'hidden')}
+                checked={utils.shouldBeChecked(value, Array.isArray(option) ? option.join('') : option)}
+                on:change={handleOptionSelect.bind(null, Array.isArray(option) ? option.join('') : option)}
+                on:input|stopPropagation
+                on:focus|preventDefault|stopPropagation
+              >
+
+              {#if search}
+
+                <span class='flex w-full gap-2 text-ellipsis whitespace-nowrap'>
+                  {#each splitOptionOnWord(option) as word, wordIndex}
+                    <span class={cx('inline-block', {
+                      'w-5 text-gray-800': hasPrefix && wordIndex === 0,
+                    })}>
+                      {#each [...word] as token}
+                        <span class={cx({
+                          'bg-yellow-100': token !== ' ' && typeof search[1] === 'string' && search[1].includes(token),
+                        })}>{token}</span>
+                      {/each}
+                    </span>
+                  {/each}
+                </span>
+
+              {:else if hasPrefix}
+
+                {#each splitOptionOnWord(option) as optionPart, optionPartIndex (optionPart)}
+                  <span
+                    class={optionPartIndex === 0 ? 'text-gray-800 w-5' : ''}
+                  >
+                    { optionPart }
+                  </span>
+                {/each}
+
+              {:else}
+                { option }
+              {/if}
+            </label>
+          {/each}
+          {#if isMultiple && canClearAll}
+            <button
+              class='w-full px-2 py-1 hover:bg-slate-200 text-xs text-left'
+              on:mouseenter={clearNavigationIndex}
+              on:click={handleClearAll}
+            >
+              Clear all
+            </button>
+            {/if}
+        </div>
+
+      {:else}
+        <div class='flex py-1.5 px-2.5 justify-center text-xs'>
+          No matching results
+        </div>
+      {/if}
+      
+      {#if hasButton}
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <div 
+          class='flex cursor-pointer hover:bg-gray-200 items-center p-2 border-t-[1px] border-t-gray-200 '
+          on:click={handleButtonClick}
+        >
+          {#if buttonicon}
+            <v-icon name={buttonicon}/>
+          {/if}
+          <span class='text-xs pl-2'>{buttontext}</span>
+        </div>
+      {/if}
+    </div>
+  </v-dropdown>
+</label>
+
+<style>
+.options-container::-webkit-scrollbar {
+  width: 6px;
+}
+
+.options-container::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.options-container::-webkit-scrollbar-thumb {
+  background-color: black;
+  border-radius: 0;
+  border: 0 solid transparent;
+}
+
+.options-container {
+  scrollbar-width: thin;
+  scrollbar-color: black transparent;
+}
+</style>

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -77,6 +77,9 @@ const setKeyboardControl = (toggle: boolean) => {
 };
 
 const applySearchSort = (term: string, options: string[]) => {
+  if (options[0] === '' && options.length === 1){
+    return [];
+  }
   dispatch('search', { term });
   return term ? searchSort(options, term, isReduceSort) : options;
 };
@@ -208,7 +211,7 @@ const handleClearAll = () => {
   value = '';
   optionsContainer.scrollTop = 0;
   dispatch('input', { value, values: value.split(',') });
-
+  dispatch('clear-all-click');
 };
 
 const handleButtonClick = () => {

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -136,7 +136,7 @@ const handleNavigate = (direction: number) => {
     navigationIndex = 0;
   }
 
-  const element = optionsContainer.children[navigationIndex]!;
+  const element = optionsContainer.children[0]!.children[navigationIndex]!;
 
   if (utils.isElementInScrollView(element) === false) {
     element.scrollIntoView();

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -360,7 +360,6 @@ $: {
                 </span>
 
               {:else if hasPrefix}
-
                 {#each splitOptionOnWord(option) as optionPart, optionPartIndex (optionPart)}
                   <span
                     class={optionPartIndex === 0 ? 'text-gray-800 w-5' : ''}

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -12,6 +12,7 @@ import { addStyles } from '../../lib/index';
 import { dispatcher } from '../../lib/dispatch';
 import * as utils from './utils';
 
+
 export let options = '';
 export let value = '';
 export let placeholder = '';
@@ -26,8 +27,7 @@ export let clearable = 'true';
 export let withbutton = 'false';
 export let buttontext = 'ENTER';
 export let buttonicon = '';
-export let reducesort = 'false';
-export let dosearch = 'true';
+export let sortoption: utils.SortOptions = 'default';
 export let heading = '';
 
 const dispatch = dispatcher();
@@ -56,8 +56,8 @@ $: hasPrefix = htmlToBoolean(prefix, 'prefix');
 $: showsPill = htmlToBoolean(showpill, 'showpill');
 $: canClearAll = htmlToBoolean(clearable, 'clearable');
 $: hasButton = htmlToBoolean(withbutton, 'withbutton');
-$: isReduceSort = htmlToBoolean(reducesort, 'reducesort');
-$: doesSearch = htmlToBoolean(dosearch, 'dosearch');
+$: isReduceSort = sortoption === 'reduce';
+$: doesSearch = sortoption !== 'off';
 $: parsedOptions = options.split(',').map((str) => str.trim());
 $: parsedSelected = value.split(',').filter(Boolean).map((str) => str.trim());
 $: sortedOptions = doesSearch ? applySearchSort(searchTerm, parsedOptions) : parsedOptions;

--- a/src/elements/select/select-button.svelte
+++ b/src/elements/select/select-button.svelte
@@ -1,0 +1,32 @@
+
+<svelte:options immutable tag='v-select-button' />
+
+<script lang='ts'>
+
+import { addStyles } from '../../lib/index';
+import { dispatcher } from '../../lib/dispatch';
+
+
+export let buttontext = 'ENTER';
+export let buttonicon = '';
+
+const dispatch = dispatcher();
+
+addStyles();
+
+const handleButtonClick = () => {
+  dispatch('button-click');
+};
+
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<div 
+  class='flex cursor-pointer hover:bg-gray-200 items-center p-2 border-t-[1px] border-t-gray-200 '
+  on:click={handleButtonClick}
+  >
+  {#if buttonicon}
+    <v-icon name={buttonicon}/>
+  {/if}
+  <span class='text-xs pl-2'>{buttontext}</span>
+</div>

--- a/src/elements/select/select-button.svelte
+++ b/src/elements/select/select-button.svelte
@@ -4,26 +4,17 @@
 <script lang='ts'>
 
 import { addStyles } from '../../lib/index';
-import { dispatcher } from '../../lib/dispatch';
-
 
 export let buttontext = 'ENTER';
 export let buttonicon = '';
 
-const dispatch = dispatcher();
-
 addStyles();
-
-const handleButtonClick = () => {
-  dispatch('button-click');
-};
 
 </script>
 
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <div 
   class='flex cursor-pointer hover:bg-gray-200 items-center p-2 border-t-[1px] border-t-gray-200 '
-  on:click={handleButtonClick}
   >
   {#if buttonicon}
     <v-icon name={buttonicon}/>

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -10,6 +10,7 @@ import { searchSort } from '../../lib/sort';
 import { htmlToBoolean } from '../../lib/boolean';
 import { addStyles } from '../../lib/index';
 import { dispatcher } from '../../lib/dispatch';
+import SelectButton from './select-button.svelte';
 import * as utils from './utils';
 
 export let options = '';
@@ -457,16 +458,11 @@ $: {
       {/if}
       
       {#if hasButton}
-        <!-- svelte-ignore a11y-click-events-have-key-events -->
-        <div 
-          class='flex cursor-pointer hover:bg-gray-200 items-center p-2 border-t-[1px] border-t-gray-200 '
-          on:click={handleButtonClick}
-        >
-          {#if buttonicon}
-            <v-icon name={buttonicon}/>
-          {/if}
-          <span class='text-xs pl-2'>{buttontext}</span>
-        </div>
+        <SelectButton
+        buttontext={buttontext}
+        buttonicon={buttonicon}
+        on:button-click={handleButtonClick}
+      />
       {/if}
     </div>
   </v-dropdown>

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -164,7 +164,7 @@ const handleNavigate = (direction: number) => {
     navigationIndex = 0;
   }
 
-  const element = optionsContainer.children[navigationIndex]!;
+  const element = optionsContainer.children[0]!.children[navigationIndex]!;
 
   if (utils.isElementInScrollView(element) === false) {
     element.scrollIntoView();

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -30,7 +30,6 @@ export let withbutton = 'false';
 export let buttontext = 'ENTER';
 export let buttonicon = '';
 export let reducesort = 'false';
-export let dosearch = 'true';
 
 const dispatch = dispatcher();
 
@@ -48,7 +47,6 @@ let showsPill: boolean;
 let canClearAll: boolean;
 let hasButton: boolean;
 let isReduceSort: boolean;
-let doesSearch: boolean
 let parsedOptions: string[];
 let parsedSelected: string[];
 let sortedOptions: string[];
@@ -64,16 +62,15 @@ $: showsPill = htmlToBoolean(showpill, 'showpill');
 $: canClearAll = htmlToBoolean(clearable, 'clearable');
 $: hasButton = htmlToBoolean(withbutton, 'withbutton');
 $: isReduceSort = htmlToBoolean(reducesort, 'reducesort');
-$: doesSearch = htmlToBoolean(dosearch, 'dosearch');
 $: parsedOptions = options.split(',').map((str) => str.trim());
 $: parsedSelected = isMultiple
   ? value.split(',').filter(Boolean).map((str) => str.trim())
   : [];
-$: sortedOptions = determineSortedOptions(parsedOptions, doesSearch);
-$: searchedOptions = doesSearch ? (isMultiple ? 
+$: sortedOptions = isMultiple ? applySearchSort(searchTerm, parsedOptions) : 
+applySearchSort(value, parsedOptions);
+$: searchedOptions = isMultiple ? 
 utils.applySearchHighlight(sortedOptions, searchTerm) : 
-utils.applySearchHighlight(sortedOptions, value)) :
-utils.applySearchHighlight(sortedOptions, '');
+utils.applySearchHighlight(sortedOptions, value);
 
 let open = false;
 let navigationIndex = -1;
@@ -90,28 +87,6 @@ const applySearchSort = (term: string, options: string[]) => {
   dispatch('search', { term })
   return term ? searchSort(options, term, isReduceSort) : options;
 };
-
-const determineSortedOptions = (inputOptions: string[], search: boolean) => {
-  if (!search) {
-    return inputOptions;
-  }
-  if (isMultiple) {
-    return applySearchSort(searchTerm, inputOptions);
-  } else {
-    return applySearchSort(value, inputOptions);
-  }
-}
-
-// const transformToSearchedOptions = (sorted: string[], search: boolean, term: string) => {
-//   if (!search) {
-//     return utils.applySearchHighlight(sorted, '');
-//   }
-//   if (isMultiple) {
-//     return utils.applySearchHighlight(sorted, term);
-//   } else {
-//     return utils.applySearchHighlight(sorted, value);
-//   }
-// }
 
 const handleInput = (event: Event) => {
   navigationIndex = -1;
@@ -178,7 +153,6 @@ const handleEnter = () => {
 
     dispatch('input', { value });
   }
-  
 };
 
 const handleNavigate = (direction: number) => {

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -67,10 +67,10 @@ $: parsedSelected = isMultiple
   ? value.split(',').filter(Boolean).map((str) => str.trim())
   : [];
 $: sortedOptions = isMultiple ? applySearchSort(searchTerm, parsedOptions) : 
-applySearchSort(value, parsedOptions);
+  applySearchSort(value, parsedOptions);
 $: searchedOptions = isMultiple ? 
-utils.applySearchHighlight(sortedOptions, searchTerm) : 
-utils.applySearchHighlight(sortedOptions, value);
+  utils.applySearchHighlight(sortedOptions, searchTerm) : 
+  utils.applySearchHighlight(sortedOptions, value);
 
 let open = false;
 let navigationIndex = -1;
@@ -84,7 +84,7 @@ const setKeyboardControl = (toggle: boolean) => {
 };
 
 const applySearchSort = (term: string, options: string[]) => {
-  dispatch('search', { term })
+  dispatch('search', { term });
   return term ? searchSort(options, term, isReduceSort) : options;
 };
 
@@ -359,10 +359,13 @@ $: {
       slot='content'
       class='mt-1 border border-black bg-white drop-shadow-md'
     >
+    <div
+      bind:this={optionsContainer}
+      class='options-container overflow-y-auto'
+    >
       {#if sortedOptions.length > 0}
         <div
-          bind:this={optionsContainer}
-          class='options-container flex max-h-36 flex-col overflow-y-auto'
+          class='flex max-h-36 flex-col '
           on:mouseleave={clearNavigationIndex}
         >
           {#each searchedOptions as { search, option }, index (option)}
@@ -430,7 +433,7 @@ $: {
           No matching results
         </div>
       {/if}
-      
+    </div>
       {#if hasButton}
         <SelectButton
         buttontext={buttontext}

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -10,7 +10,6 @@ import { searchSort } from '../../lib/sort';
 import { htmlToBoolean } from '../../lib/boolean';
 import { addStyles } from '../../lib/index';
 import { dispatcher } from '../../lib/dispatch';
-import SelectButton from './select-button.svelte';
 import * as utils from './utils';
 
 export let options = '';
@@ -435,10 +434,11 @@ $: {
       {/if}
     </div>
       {#if hasButton}
-        <SelectButton
+        <!-- svelte-ignore a11y-click-events-have-key-events -->
+        <v-select-button
         buttontext={buttontext}
         buttonicon={buttonicon}
-        on:button-click={handleButtonClick}
+        on:click={handleButtonClick}
       />
       {/if}
     </div>

--- a/src/elements/select/utils.ts
+++ b/src/elements/select/utils.ts
@@ -3,6 +3,8 @@ interface Match {
   option: string,
 }
 
+export type SortOptions = 'default' | 'reduce' | 'off'
+
 export const isElementInScrollView = (element: Element) => {
   const { top, bottom } = element.getBoundingClientRect();
   const parentRect = element.parentElement!.parentElement!.getBoundingClientRect();

--- a/src/elements/select/utils.ts
+++ b/src/elements/select/utils.ts
@@ -15,8 +15,6 @@ export const shouldBeChecked = (value: string, option: string) => {
 };
 
 export const applySearchHighlight = (options: string[], value: string) => {
-  console.log('apply search highlight');
-  console.log(options);
   if (!value) {
     return options.map((option) => ({ search: undefined, option }));
   }
@@ -44,8 +42,6 @@ export const applySearchHighlight = (options: string[], value: string) => {
   }
 
   sortArr(matches);
-
-  console.log([...matches, ...noMatches]);
   return [...matches, ...noMatches];
 };
 

--- a/src/elements/select/utils.ts
+++ b/src/elements/select/utils.ts
@@ -1,3 +1,8 @@
+interface Match { 
+  search: string[],
+  option: string,
+}
+
 export const isElementInScrollView = (element: Element) => {
   const { top, bottom } = element.getBoundingClientRect();
   const parentRect = element.parentElement!.getBoundingClientRect();
@@ -36,13 +41,43 @@ export const applySearchHighlight = (options: string[], value: string) => {
     }
   }
 
-  matches.sort((a, b) => {
+  sortArr(matches);
+
+  return [...matches, ...noMatches];
+};
+
+export const matchingOnly = (options: string[], value: string) => {
+  if (!value) {
+    return options.map((option) => ({ search: undefined, option }));
+  }
+
+  const matches = [];
+
+  for (const option of options) {
+    const match = option.match(new RegExp(value, 'i'));
+
+    if (match?.index !== undefined) {
+      const begin = option.slice(0, match.index);
+      const middle = option.slice(match.index, match.index + value.length);
+      const end = option.slice(match.index + value.length);
+      matches.push({
+        search: [begin, middle, end],
+        option,
+      });
+    } 
+  }
+
+  sortArr(matches);
+
+  return [...matches];
+};
+
+const sortArr = (arr: Match[]) => {
+  arr.sort((a, b) => {
     if (a.option.indexOf(a.search[1]!) < b.option.indexOf(b.search[1]!)) {
       return -1;
     }
 
     return 1;
   });
-
-  return [...matches, ...noMatches];
 };

--- a/src/elements/select/utils.ts
+++ b/src/elements/select/utils.ts
@@ -15,6 +15,8 @@ export const shouldBeChecked = (value: string, option: string) => {
 };
 
 export const applySearchHighlight = (options: string[], value: string) => {
+  console.log('apply search highlight');
+  console.log(options);
   if (!value) {
     return options.map((option) => ({ search: undefined, option }));
   }
@@ -43,6 +45,7 @@ export const applySearchHighlight = (options: string[], value: string) => {
 
   sortArr(matches);
 
+  console.log([...matches, ...noMatches]);
   return [...matches, ...noMatches];
 };
 

--- a/src/elements/select/utils.ts
+++ b/src/elements/select/utils.ts
@@ -5,7 +5,7 @@ interface Match {
 
 export const isElementInScrollView = (element: Element) => {
   const { top, bottom } = element.getBoundingClientRect();
-  const parentRect = element.parentElement!.getBoundingClientRect();
+  const parentRect = element.parentElement!.parentElement!.getBoundingClientRect();
 
   return (bottom < parentRect.bottom && top > parentRect.top);
 };

--- a/src/lib/sort.ts
+++ b/src/lib/sort.ts
@@ -33,7 +33,7 @@ export const searchSort = (data: string[], searchTerm: string, reduce: boolean) 
 
   if (reduce) {
     for (const key of Object.keys(results)) {
-      if (Number(key) !== -1) {
+      if (Number.parseInt(key, 10) !== -1) {
         const sorted = (results[key] || []);
         finalResults.push(...sorted);
       }

--- a/src/lib/sort.ts
+++ b/src/lib/sort.ts
@@ -1,5 +1,5 @@
 /* eslint-disable unicorn/prefer-regexp-test */
-export const searchSort = (data: string[], searchTerm: string) => {
+export const searchSort = (data: string[], searchTerm: string, reduce: boolean) => {
   const results: Record<string, string[]> = {};
 
   const initialCharacterMatch = new RegExp(`^${searchTerm}`, 'i');
@@ -15,6 +15,7 @@ export const searchSort = (data: string[], searchTerm: string) => {
 
       if (word.match(initialCharacterMatch)) {
         index = 0;
+        break;
       } else if (word.match(anyMatch)) {
         index = i + 1;
       }
@@ -22,7 +23,7 @@ export const searchSort = (data: string[], searchTerm: string) => {
 
     if (results[index]) {
       results[index]!.push(datum);
-    } else {
+    } else if (!reduce) {
       results[index] = [datum];
     }
   }

--- a/src/lib/sort.ts
+++ b/src/lib/sort.ts
@@ -23,17 +23,26 @@ export const searchSort = (data: string[], searchTerm: string, reduce: boolean) 
 
     if (results[index]) {
       results[index]!.push(datum);
-    } else if (!reduce) {
+    } else {
       results[index] = [datum];
     }
   }
 
   const finalResults: string[] = [];
 
-  for (const key of Object.keys(results)) {
-    const sorted = (results[key] || []);
-    
-    finalResults.push(...sorted);
+
+  if (reduce) {
+    for (const key of Object.keys(results)) {
+      if (Number(key) !== -1) {
+        const sorted = (results[key] || []);
+        finalResults.push(...sorted);
+      }
+    }
+  } else {
+    for (const key of Object.keys(results)) {
+      const sorted = (results[key] || []);
+      finalResults.push(...sorted);
+    }
   }
 
   return finalResults;

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ if (customElements.get('v-badge')) {
   import('./elements/pill.svelte');
   import('./elements/radio.svelte');
   import('./elements/select/select.svelte');
+  import('./elements/select/multiselect.svelte');
   import('./elements/slider.svelte');
   import('./elements/switch.svelte');
   import('./elements/table/table.svelte');

--- a/src/stories/multiselect.stories.mdx
+++ b/src/stories/multiselect.stories.mdx
@@ -1,0 +1,335 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs'
+import gpioOptions from './assets/gpio-options'
+import MultiSelect from './../elements/select/multiselect.svelte'
+
+<Meta
+  title='Elements/Select/Multi-Select'
+  parameters={{
+    actions: {
+      handles: ['input', 'button-click', 'search'],
+    },
+  }}
+  component={MultiSelect}
+  argTypes={{
+    label: {
+      description: 'The label of the multiselect',
+      table: { 
+        defaultValue: { summary: '' },
+        type: { summary: 'string' }
+      },
+      control: 'text'
+    },
+    options: {
+      description: 'The list of options that can be selected from, separated by commas',
+      table: { 
+        defaultValue: { summary: '' },
+        type: { summary: 'string' }
+      },
+      control: 'text'
+    },
+    value: {
+      description: 'Options that are selected',
+      table: { 
+        defaultValue: { summary: '' },
+        type: { summary: 'string' }
+      },
+      control: 'text'
+    },
+    placeholder: {
+      description: 'The placeholder value in input',
+      table: { 
+        defaultValue: { summary: '' },
+        type: { summary: 'string' }
+      },
+      control: 'text'
+    },
+    showpill: { 
+      description: 'The option to show pills representing selected values',
+      table: { 
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' }
+      },
+      control: { type: 'boolean' }
+    },
+    clearable: {
+      description: 'Option to have "Clear all" button to deselect all options',
+      table: {
+        defaultValue: { summary: 'true' },
+        type: { summary: 'boolean' }
+      },
+      control: { type: 'boolean' }
+    },
+    withbutton: {
+      description: 'Whether a button exists at the bottom to conduct an action',
+      table: { 
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean' }
+      },
+      control: { type: 'boolean' }
+    },
+    buttontext: {
+      description: 'Text on the button',
+      table: { 
+        defaultValue: { summary: 'ENTER' },
+        type: { summary: 'string' }
+      },
+      control: 'text'
+    },
+    buttonicon: {
+      description: 'Icon on the button, can use any from v-icon',
+      table: { 
+        defaultValue: { summary: '' },
+        type: { summary: 'string' }
+      },
+      control: 'text'
+    },
+    reducesort: {
+      description: 'If true, only results with matching elements will display on search',
+      table: { 
+        defaultValue: { summary: 'false' },
+        type: { summary: 'boolean'}
+       },
+      control: { type: 'boolean' }
+    }, 
+    dosearch: {
+      description: 'Whether results will be searched inside of the component',
+      table: { 
+        defaultValue: { summary: 'true' },
+        type: { summary: 'boolean'}
+      },
+      control: { type: 'boolean' }
+    },
+    'on:input': {
+      description: 'Event fired when an option is selected',
+      table: { 
+        type: { summary: 'object' }
+      },
+    },
+    'on:button-click': {
+      description: 'Event fired when button is clicked',
+      table: { 
+      },
+    },
+    'on:search': {
+      description: 'Event fired when the search input is changed',
+      table: { 
+        type: { summary: 'string' },
+      },
+    },
+  }}
+/>
+
+
+# Multi-Select
+
+Dropdown that allows the user to select multiple choices.
+
+<Canvas>
+  <Story
+    name='Default'
+    args={{
+      label: "Default Multi-select",
+      options: 'happy, sad, angry',
+    }}
+  >
+    {({label, options}) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name="With Value and Placeholder"
+    args={{
+      label: "With Value and Placeholder",
+      options: "Option 1, Option 2, Option 3",
+      value: "Option 1, Option 3",
+      placeholder: "Some placeholder..."
+    }}
+  >
+    {({ label, options, value, placeholder }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        value='${value}'
+        placeholder='${placeholder}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+
+<Canvas>
+  <Story
+    name='With Button'
+    args={{
+      label: 'With Button',
+      options: 'Photo 1, Photo 2, Photo 3',
+      withbutton: 'true',
+      buttontext: 'TAKE PHOTO',
+      buttonicon: 'camera',
+    }}
+  >
+    {({ label, options, withbutton, buttontext, buttonicon }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        withbutton='${withbutton}'
+        buttontext='${buttontext}'
+        buttonicon='${buttonicon}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Disabled'
+    args={{
+      label: 'Your options',
+      options: 'Option 1, Option 2, Option 3',
+      disabled: 'true',
+      tooltip: 'This is disabled.',
+      state: 'error',
+    }}
+  >
+    {({ label, options, disabled, tooltip, state }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        disabled='${disabled}'
+        tooltip='${tooltip}'
+        state='${state}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+
+<Canvas>
+  <Story
+    name='With Tooltip'
+    args={{
+      label: 'With Tooltip',
+      options: 'Option 1, Option 2, Option 3',
+      value: 'Option',
+      tooltip: 'Warning: these options may not be your only options.',
+      state: 'warn',
+    }}
+  >
+    {({ label, options, value, tooltip, state }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        value='${value}'
+        tooltip='${tooltip}'
+        state='${state}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='With prefix'
+    args={{
+      label: 'Options With Prefixes',
+      options: gpioOptions,
+      placeholder: 'Select...',
+      prefix: 'true',
+    }}
+  >
+    {({ label, options, placeholder, prefix }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        placeholder='${placeholder}'
+        prefix='${prefix}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Show Pills'
+    args={{
+      label: 'Show Pills',
+      options: 'Bob, Sally, Jimothy, Raechel, Apple, Andy, Robert',
+      value: 'Jimothy, Apple',
+      showpill: 'true',
+    }}
+  >
+    {({ label, options, value, showpill  }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        value='${value}'
+        showpill='${showpill}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Reduce Search'
+    args={{
+      label: 'Reduce Search',
+      options: 'hello, hi, yo, halo',
+      reducesort: 'true',
+    }}
+  >
+    {({ label, options, reducesort }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        reducesort='${reducesort}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Do Not Search'
+    args={{
+      label: 'Do Not Search',
+      options: 'hello, hi, yo, halo',
+      dosearch: 'false',
+    }}
+  >
+    {({ label, options, dosearch }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        dosearch='${dosearch}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Not Clearable'
+    args={{
+      label: 'Not Clearable',
+      options: 'hello, hi, yo, halo',
+      value: 'hi, halo',
+      clearable: 'false',
+    }}
+  >
+    {({ label, options, clearable, value }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        clearable='${clearable}'
+        value='${value}'
+      />
+    `}
+  </Story>
+</Canvas>

--- a/src/stories/multiselect.stories.mdx
+++ b/src/stories/multiselect.stories.mdx
@@ -6,7 +6,7 @@ import MultiSelect from './../elements/select/multiselect.svelte'
   title='Elements/Select/Multi-Select'
   parameters={{
     actions: {
-      handles: ['input', 'button-click', 'search'],
+      handles: ['input', 'button-click', 'search', 'clear-all-click'],
     },
   }}
   component={MultiSelect}

--- a/src/stories/multiselect.stories.mdx
+++ b/src/stories/multiselect.stories.mdx
@@ -115,14 +115,15 @@ import MultiSelect from './../elements/select/multiselect.svelte'
     },
     'on:button-click': {
       description: 'Event fired when button is clicked',
-      table: { 
-      },
     },
     'on:search': {
       description: 'Event fired when the search input is changed',
       table: { 
         type: { summary: 'string' },
       },
+    },
+    'on:clear-all-click': {
+      description: 'Event fired when "Clear All" is pressed and values are cleared',
     },
   }}
 />

--- a/src/stories/multiselect.stories.mdx
+++ b/src/stories/multiselect.stories.mdx
@@ -99,6 +99,14 @@ import MultiSelect from './../elements/select/multiselect.svelte'
       },
       control: { type: 'boolean' }
     },
+    heading: {
+      description: 'Subheading inside the dropdown to describe the information',
+      table: { 
+        defaultValue: { summary: '' },
+        type: { summary: 'string'}
+      },
+      control: 'text'
+    },
     'on:input': {
       description: 'Event fired when an option is selected',
       table: { 
@@ -181,6 +189,25 @@ Dropdown that allows the user to select multiple choices.
         withbutton='${withbutton}'
         buttontext='${buttontext}'
         buttonicon='${buttonicon}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='With Heading'
+    args={{
+      label: 'With Heading',
+      options: 'a1, a2, a3, a4',
+      heading: 'A Values'
+    }}
+  >
+    {({ label, options, heading}) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        heading='${heading}'
       />
     `}
   </Story>

--- a/src/stories/select.stories.mdx
+++ b/src/stories/select.stories.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs'
 import gpioOptions from './assets/gpio-options'
 
 <Meta
-  title='Elements/Select'
+  title='Elements/Select/Select'
   parameters={{
     actions: {
       handles: ['input', 'button-click', 'search'],
@@ -30,13 +30,18 @@ import gpioOptions from './assets/gpio-options'
       control: 'text'
     },
     showpill: { 
-      description: 'when in multi-select variant, have the option to show pills in the select representing selected values',
+      description: 'When in multi-select variant, have the option to show pills in the select representing selected values',
       table: { defaultValue: { summary: 'false' } },
       control: { type: 'boolean' }
     },
     clearable: {
-      description: 'option to show the clear all button to deselect all otpions',
+      description: 'Option to have the "Clear All" button to deselect all otpions',
       table: { defaultValue: { summary: 'true' } },
+      control: { type: 'boolean' }
+    },
+    exact: {
+      description: 'If true, values can only be selected if an existing value matches what is inputted (single select ONLY)',
+      table: { defaultValue: { summary: 'false' } },
       control: { type: 'boolean' }
     },
     withbutton: {
@@ -53,6 +58,11 @@ import gpioOptions from './assets/gpio-options'
       description: 'The icon on the button, can use any from v-icon',
       table: { defaultValue: { summary: '' } },
       control: 'text'
+    },
+    reducesort: {
+      description: 'If true, only results with matching elements will display on search',
+      table: { defaultValue: { summary: 'false' } },
+      control: { type: 'boolean' }
     },
     'on:input': {
       description: 'Event fired when an option is selected'


### PR DESCRIPTION
Functionalities included in this PR:
- added `dosearch` prop, if false, then sort will not be done within component
- added `reducesort` prop, if true, will only show matching results instead of priority listing
- split up v-select to a separate v-multiselect which has functionalities that only apply to multi select. The select component will be refactored in the future to only have single select features
- add `heading` prop, if has value, then will show a heading within the dropdown

heading preview:
<img width="817" alt="Screen Shot 2022-12-06 at 2 49 25 PM" src="https://user-images.githubusercontent.com/29152328/206010103-07b354f8-7238-449b-9914-8d9e47b2d821.png">
