### PR TITLE
remove overflow-hidden on collapse component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.88",
+      "version": "0.0.89",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.88",
+  "version": "0.0.89",
   "license": "Apache-2.0",
   "type": "commonjs",
   "files": [

--- a/src/elements/collapse.svelte
+++ b/src/elements/collapse.svelte
@@ -27,7 +27,7 @@ const handleClick = (event: Event) => {
 
 </script>
 
-<div class='relative w-full overflow-hidden'>
+<div class='relative w-full'>
   <div
     class={cx('w-full py-2 px-4 flex flex-reverse items-center justify-between text-black cursor-pointer', {
       'border border-black bg-white': variant === 'default',

--- a/src/elements/collapse.svelte
+++ b/src/elements/collapse.svelte
@@ -58,7 +58,7 @@ const handleClick = (event: Event) => {
   </div>
 
   <div
-    class="{cx(' text-black overflow-hidden transition-all duration-500', {
+    class="{cx(' text-black transition-all duration-500', {
       'bg-white': variant === 'default',
       'max-h-0': !open,
       'max-h-fit': open,


### PR DESCRIPTION
Currently items inside v-collapse are getting clipped. This removes overflow-hidden.

<img width="544" alt="image" src="https://user-images.githubusercontent.com/17263/206286139-1ec11c5c-4062-4233-89f6-ec04f0527bdc.png">
