### PR TITLE
Adds new event types and makes search term a controlled input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.90",
+      "version": "0.0.91",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "license": "Apache-2.0",
   "type": "commonjs",
   "files": [

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -87,7 +87,7 @@ const handleInput = (event: Event) => {
   optionsContainer.scrollTop = 0;
   event.stopImmediatePropagation();
 
-  const newTerm = input.value.trim()
+  const newTerm = input.value.trim();
   dispatch('search', { term: newTerm });
 
   optionMatch = false;
@@ -225,9 +225,9 @@ const splitOptionOnWord = (option: string) => {
 
 $: {
   if (open) {
-    dispatch('open')
+    dispatch('open');
   } else {
-    dispatch('close')
+    dispatch('close');
   }
 }
 

--- a/src/stories/multiselect.stories.mdx
+++ b/src/stories/multiselect.stories.mdx
@@ -6,7 +6,7 @@ import MultiSelect from './../elements/select/multiselect.svelte'
   title='Elements/Select/Multi-Select'
   parameters={{
     actions: {
-      handles: ['input', 'button-click', 'search', 'clear-all-click'],
+      handles: ['input', 'button-click', 'search', 'clear-all-click', 'enter-press', 'open', 'close'],
     },
   }}
   component={MultiSelect}
@@ -121,6 +121,15 @@ import MultiSelect from './../elements/select/multiselect.svelte'
       table: { 
         type: { summary: 'string' },
       },
+    },
+    'on:enter-press': {
+      description: 'Event fired when enter button is pressed',
+    },
+    'on:open': {
+      description: 'Event fired when dropdown opens',
+    },
+    'on:close': {
+      description: 'Event fired when dropdown closes',
     },
     'on:clear-all-click': {
       description: 'Event fired when "Clear All" is pressed and values are cleared',


### PR DESCRIPTION
Adding a bunch of new event types (enter-press, open, close) and allowing search term to be controlled. We want to be able to manipulate the search term at the point of implementation as needed for a variety of things like programmatically clearing the term or lowercasing.

There was also a bug where an having an empty array would prevent the search event from dispatching - this also fixes that by having the `handleInput` dispatch the event immediately rather than being contingent upon the search being applied