### PR TITLE
fix multiselect value check

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.93",
+      "version": "0.0.94",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.19.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.93",
+  "version": "0.0.94",
   "license": "Apache-2.0",
   "type": "commonjs",
   "files": [

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -118,11 +118,11 @@ const handleChange = (changedOption: string) => {
   if (parsedSelected.includes(changedOption)) {
     const newValue = [...parsedSelected.filter(item => item !== changedOption)];
     value = newValue.toString();
-    dispatch('input', { value , values: newValue, removed: changedOption });
+    dispatch('input', { value, values: newValue, removed: changedOption });
   } else {
     const newValue = [...parsedSelected, changedOption];
     value = newValue.toString();
-    dispatch('input', { value , values: newValue, added: changedOption });
+    dispatch('input', { value, values: newValue, added: changedOption });
   }
   input.focus();
 };
@@ -178,8 +178,8 @@ const handleIconClick = () => {
 
 const handlePillClick = (target: string) => {
   const newValue = [...parsedSelected.filter((item: string) => item !== target)];
-  value = newValue.toString()
-  dispatch('input', { value , values: newValue, removed: target });
+  value = newValue.toString();
+  dispatch('input', { value, values: newValue, removed: target });
   input.focus();
 };
 
@@ -202,7 +202,7 @@ const handleOptionSelect = (target: string, event: Event) => {
     ? [...parsedSelected, target]
     : [...parsedSelected.filter((item: string) => item !== target)];
 
-  value = newValue.toString()
+  value = newValue.toString();
 
   input.focus();
   if (checked) {

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -101,7 +101,7 @@ const handleKeyUp = (event: KeyboardEvent) => {
 const handleEnter = () => {
   if (navigationIndex === -1) {
     // if user hits enter when focused on the search input
-    const match = sortedOptions.find((opt) => opt.toLowerCase() === searchterm.toLowerCase())
+    const match = sortedOptions.find((opt) => opt.toLowerCase() === searchterm.toLowerCase());
     if (match) {
       handleChange(match);
     } else {
@@ -110,19 +110,19 @@ const handleEnter = () => {
   } else {
     // if the user has used arrow keys to navigate options, enter should add/remove item
     const option = sortedOptions[navigationIndex]!;
-    handleChange(option)
+    handleChange(option);
   }
 };
 
 const handleChange = (changedOption: string) => {
-    if (parsedSelected.includes(changedOption)) {
-      const newValue = [...parsedSelected.filter(item => item !== changedOption)];
-      dispatch('input', { value: newValue.toString(), values: newValue, removed: changedOption });
-    } else {
-      const newValue = [...parsedSelected, changedOption];
-      dispatch('input', { value: newValue.toString(), values: newValue, added: changedOption });
-    }
-    input.focus();
+  if (parsedSelected.includes(changedOption)) {
+    const newValue = [...parsedSelected.filter(item => item !== changedOption)];
+    dispatch('input', { value: newValue.toString(), values: newValue, removed: changedOption });
+  } else {
+    const newValue = [...parsedSelected, changedOption];
+    dispatch('input', { value: newValue.toString(), values: newValue, added: changedOption });
+  }
+  input.focus();
 };
 
 

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -344,7 +344,7 @@ $: {
                 tabindex="-1"
                 type='checkbox'
                 class={cx('bg-black outline-none')}
-                checked={utils.shouldBeChecked(value, Array.isArray(option) ? option.join('') : option)}
+                checked={utils.shouldBeChecked(parsedSelected.toString(0), Array.isArray(option) ? option.join('') : option)}
                 on:change={handleOptionSelect.bind(null, Array.isArray(option) ? option.join('') : option)}
                 on:input|stopPropagation
                 on:focus|preventDefault|stopPropagation

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -101,20 +101,30 @@ const handleKeyUp = (event: KeyboardEvent) => {
 const handleEnter = () => {
   if (navigationIndex === -1) {
     // if user hits enter when focused on the search input
-    dispatch('enter-press');
+    const match = sortedOptions.find((opt) => opt.toLowerCase() === searchterm.toLowerCase())
+    if (match) {
+      handleChange(match);
+    } else {
+      dispatch('enter-press', { options: sortedOptions });
+    }
   } else {
     // if the user has used arrow keys to navigate options, enter should add/remove item
     const option = sortedOptions[navigationIndex]!;
-    if (value.includes(option)) {
-      const newValue = [...parsedSelected.filter(item => item !== option)];
-      dispatch('input', { value: newValue.toString(), values: newValue, removed: option });
-    } else {
-      const newValue = [...parsedSelected, option];
-      dispatch('input', { value: newValue.toString(), values: newValue, added: option });
-    }
-    input.focus();
+    handleChange(option)
   }
 };
+
+const handleChange = (changedOption: string) => {
+    if (parsedSelected.includes(changedOption)) {
+      const newValue = [...parsedSelected.filter(item => item !== changedOption)];
+      dispatch('input', { value: newValue.toString(), values: newValue, removed: changedOption });
+    } else {
+      const newValue = [...parsedSelected, changedOption];
+      dispatch('input', { value: newValue.toString(), values: newValue, added: changedOption });
+    }
+    input.focus();
+};
+
 
 const handleNavigate = (direction: number) => {
   navigationIndex += direction;

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -117,10 +117,12 @@ const handleEnter = () => {
 const handleChange = (changedOption: string) => {
   if (parsedSelected.includes(changedOption)) {
     const newValue = [...parsedSelected.filter(item => item !== changedOption)];
-    dispatch('input', { value: newValue.toString(), values: newValue, removed: changedOption });
+    value = newValue.toString();
+    dispatch('input', { value , values: newValue, removed: changedOption });
   } else {
     const newValue = [...parsedSelected, changedOption];
-    dispatch('input', { value: newValue.toString(), values: newValue, added: changedOption });
+    value = newValue.toString();
+    dispatch('input', { value , values: newValue, added: changedOption });
   }
   input.focus();
 };
@@ -176,7 +178,8 @@ const handleIconClick = () => {
 
 const handlePillClick = (target: string) => {
   const newValue = [...parsedSelected.filter((item: string) => item !== target)];
-  dispatch('input', { value: newValue.toString(), values: newValue, removed: target });
+  value = newValue.toString()
+  dispatch('input', { value , values: newValue, removed: target });
   input.focus();
 };
 
@@ -199,11 +202,13 @@ const handleOptionSelect = (target: string, event: Event) => {
     ? [...parsedSelected, target]
     : [...parsedSelected.filter((item: string) => item !== target)];
 
+  value = newValue.toString()
+
   input.focus();
   if (checked) {
-    dispatch('input', { value: newValue.toString(), values: newValue, added: target });
+    dispatch('input', { value, values: newValue, added: target });
   } else {
-    dispatch('input', { value: newValue.toString(), values: newValue, removed: target });
+    dispatch('input', { value, values: newValue, removed: target });
   }
 };
 

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -106,7 +106,7 @@ const handleEnter = () => {
     // if the user has used arrow keys to navigate options, enter should add/remove item
     const option = sortedOptions[navigationIndex]!;
     if (value.includes(option)) {
-      const newValue = [...parsedSelected.filter(item => item !== option)]
+      const newValue = [...parsedSelected.filter(item => item !== option)];
       dispatch('input', { value: newValue.toString(), values: newValue, removed: option });
     } else {
       const newValue = [...parsedSelected, option];
@@ -179,11 +179,11 @@ const handleOptionMouseEnter = (index: number) => {
 };
 
 const handleOptionSelect = (target: string, event: Event) => {
-  const targetElement= event.target as HTMLInputElement
+  const targetElement = event.target as HTMLInputElement;
   const { checked } = (targetElement);
   // cannot suppress checkbox check
   if (targetElement.checked) {
-    targetElement.checked = !checked
+    targetElement.checked = !checked;
   }
   const newValue = checked
     ? [...parsedSelected, target]

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -344,7 +344,7 @@ $: {
                 tabindex="-1"
                 type='checkbox'
                 class={cx('bg-black outline-none')}
-                checked={utils.shouldBeChecked(parsedSelected.toString(0), Array.isArray(option) ? option.join('') : option)}
+                checked={utils.shouldBeChecked(parsedSelected.toString(), Array.isArray(option) ? option.join('') : option)}
                 on:change={handleOptionSelect.bind(null, Array.isArray(option) ? option.join('') : option)}
                 on:input|stopPropagation
                 on:focus|preventDefault|stopPropagation

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -106,11 +106,11 @@ const handleEnter = () => {
     // if the user has used arrow keys to navigate options, enter should add/remove item
     const option = sortedOptions[navigationIndex]!;
     if (value.includes(option)) {
-      value = [...parsedSelected.filter(item => item !== option)].toString()
-      dispatch('input', { value, values: value.split(','), removed: option });
+      const newValue = [...parsedSelected.filter(item => item !== option)]
+      dispatch('input', { value: newValue.toString(), values: newValue, removed: option });
     } else {
-      value = [...parsedSelected, option].toString();
-      dispatch('input', { value, values: value.split(','), added: option });
+      const newValue = [...parsedSelected, option];
+      dispatch('input', { value: newValue.toString(), values: newValue, added: option });
     }
     input.focus();
   }
@@ -165,8 +165,8 @@ const handleIconClick = () => {
 };
 
 const handlePillClick = (target: string) => {
-  value = [...parsedSelected.filter((item: string) => item !== target)].toString();
-  dispatch('input', { value, values: value.split(','), removed: target });
+  const newValue = [...parsedSelected.filter((item: string) => item !== target)];
+  dispatch('input', { value: newValue.toString(), values: newValue, removed: target });
   input.focus();
 };
 
@@ -179,24 +179,27 @@ const handleOptionMouseEnter = (index: number) => {
 };
 
 const handleOptionSelect = (target: string, event: Event) => {
-  const { checked } = (event.target as HTMLInputElement);
-
-  value = checked
-    ? [...parsedSelected, target].toString()
-    : [...parsedSelected.filter((item: string) => item !== target)].toString();
+  const targetElement= event.target as HTMLInputElement
+  const { checked } = (targetElement);
+  // cannot suppress checkbox check
+  if (targetElement.checked) {
+    targetElement.checked = !checked
+  }
+  const newValue = checked
+    ? [...parsedSelected, target]
+    : [...parsedSelected.filter((item: string) => item !== target)];
 
   input.focus();
   if (checked) {
-    dispatch('input', { value, values: value.split(','), added: target });
+    dispatch('input', { value: newValue.toString(), values: newValue, added: target });
   } else {
-    dispatch('input', { value, values: value.split(','), removed: target });
+    dispatch('input', { value: newValue.toString(), values: newValue, removed: target });
   }
 };
 
 const handleClearAll = () => {
-  value = '';
   optionsContainer.scrollTop = 0;
-  dispatch('input', { value, values: [] });
+  dispatch('input', { value: '', values: [] });
   dispatch('clear-all-click');
 };
 

--- a/src/elements/select/utils.ts
+++ b/src/elements/select/utils.ts
@@ -13,7 +13,7 @@ export const isElementInScrollView = (element: Element) => {
 };
 
 export const shouldBeChecked = (value: string, option: string) => {
-  return value.includes(option);
+  return value.split(',').includes(option);
 };
 
 export const applySearchHighlight = (options: string[], value: string) => {


### PR DESCRIPTION
Oops another fix! When displaying checked/unchecked value, was checking to see if the option was in the stringified list of values which meant that if you had the value set to `"gummy,bears"` and the options included `"y"`, `"y"` would be checked off because "gummy" has a "y" in it. Changed it to first convert the stringified list and then check to see if the option is in that array, which will do a full comparison of values as strings to the target option string