### PR TITLE
Slider min/max labels no longer break bounds of parent container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.105",
+      "version": "0.0.106",
       "license": "Apache-2.0",
       "devDependencies": {
         "@floating-ui/dom": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/src/elements/slider.svelte
+++ b/src/elements/slider.svelte
@@ -417,7 +417,7 @@ const onChange = () => {
 
   <div
     bind:this={slider}
-    class={cn('slider relative h-0.5 mt-7 transition-opacity duration-200 select-none pip-labels bg-black/50', {
+    class={cn('slider relative h-0.5 mt-7 transition-opacity duration-200 select-none bg-black/50', {
       'opacity-50': disabled,
     })}
     class:range
@@ -455,7 +455,7 @@ const onChange = () => {
 
         <span class={cn(
           'floating block absolute left-1/2 bottom-full -translate-x-1/2 -translate-y-1/2',
-          'py-1 px-1.5 text-sm text-center opacity-0 pointer-events-none whitespace-nowrap transition duration-200 border border-black bg-white text-xs',
+          'py-1 px-1.5 text-center opacity-0 pointer-events-none whitespace-nowrap transition duration-200 border border-black bg-white text-xs',
           {
             '-translate-y-1.5': !focus || activeHandle !== index,
           }
@@ -481,11 +481,11 @@ const onChange = () => {
       class:disabled
       class:focus 
     >
-      <small class='absolute bottom-full left-0 -translate-x-1/2 mb-3 whitespace-nowrap text-xs'>
+      <small class='absolute bottom-full left-0 mb-3 whitespace-nowrap text-xs'>
         {minNum}
         
         {#if suffix}
-          <span class='pipVal-suffix'>{suffix}</span>
+          <span>{suffix}</span>
         {/if}
       </small>
 
@@ -500,11 +500,11 @@ const onChange = () => {
         {/each}
       {/if}
 
-      <small class='absolute bottom-full right-0 translate-x-1/2 mb-3 whitespace-nowrap text-xs'>
+      <small class='absolute bottom-full right-0 mb-3 whitespace-nowrap text-xs'>
         {maxNum}
         
         {#if suffix}
-          <span class='pipVal-suffix'>{suffix}</span>
+          <span>{suffix}</span>
         {/if}
       </small>
 


### PR DESCRIPTION
Currently our min and max labels are centered over the right and left edges of the slider module. This causes layout problems when used.

<img width="582" alt="image" src="https://user-images.githubusercontent.com/17263/211944888-08723a99-9599-44d3-a9b6-af9d84787366.png">

Fix:

- Left and right align labels instead, bound to parent container.

<img width="579" alt="image" src="https://user-images.githubusercontent.com/17263/211944954-ae538bd4-a165-4c88-ba27-95c9f31bfccb.png">
