### PR TITLE
APP-1162: Give all PRIME Inputs a "readonly" State

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.106",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.106",
+      "version": "0.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@floating-ui/dom": "^1.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.0.105",
+      "version": "0.0.106",
       "license": "Apache-2.0",
       "devDependencies": {
         "@floating-ui/dom": "^1.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.106",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/src/elements/button/button.svelte
+++ b/src/elements/button/button.svelte
@@ -65,7 +65,7 @@ const handleParentClick = (event: PointerEvent) => {
     title={title}
     class={cx('will-change-transform hover:scale-105 motion-safe:transition-transform', {
       'inline-flex items-center justify-center gap-1.5 py-1.5 px-2 text-xs border': variant !== 'icon',
-      'cursor-not-allowed opacity-50 pointer-events-none': isDisabled,
+      'cursor-not-allowed text-black/50 border-black/50 pointer-events-none': isDisabled,
       'bg-white border-black': variant === 'primary',
       'bg-black border-black text-white': variant === 'inverse-primary',
       'bg-red/90 text-white border-red/90': variant === 'danger',

--- a/src/elements/input/input.svelte
+++ b/src/elements/input/input.svelte
@@ -211,6 +211,7 @@ const handleNumberDragDown = async (event: PointerEvent) => {
       <p class={cx('text-xs capitalize', {
         'inline whitespace-nowrap': labelposition === 'left',
         'opacity-50 pointer-events-none': isDisabled,
+        'opacity-75 pointer-events-none': isReadonly,
         'after:text-red-500 after:content-["*"] after:ml-1': isRequired,
       })}>
         {label}
@@ -244,6 +245,7 @@ const handleNumberDragDown = async (event: PointerEvent) => {
       'pl-3': isNumeric,
       'bg-white': !isDisabled,
       'opacity-50 pointer-events-none bg-gray-200': isDisabled || isDragging,
+      'opacity-75 pointer-events-none bg-gray-200': isReadonly,
       'border-red-600 border': state === 'error',
     })}
     step={insertStepAttribute ? step : null}

--- a/src/elements/input/input.svelte
+++ b/src/elements/input/input.svelte
@@ -210,8 +210,7 @@ const handleNumberDragDown = async (event: PointerEvent) => {
     {#if label}
       <p class={cx('text-xs capitalize', {
         'inline whitespace-nowrap': labelposition === 'left',
-        'opacity-50 pointer-events-none': isDisabled,
-        'opacity-75 pointer-events-none': isReadonly,
+        'text-black/50': isDisabled || isReadonly,
         'after:text-red-500 after:content-["*"] after:ml-1': isRequired,
       })}>
         {label}
@@ -244,8 +243,9 @@ const handleNumberDragDown = async (event: PointerEvent) => {
       'pl-2.5': isNumeric === false,
       'pl-3': isNumeric,
       'bg-white': !isDisabled,
-      'opacity-50 pointer-events-none bg-gray-200': isDisabled || isDragging,
-      'opacity-75 pointer-events-none bg-gray-200': isReadonly,
+      'bg-black/20': (isDisabled || isDragging || isReadonly),
+      'border-black/50': isDisabled || isReadonly,
+      'text-black/50': isDisabled || isReadonly,
       'border-red-600 border': state === 'error',
     })}
     step={insertStepAttribute ? step : null}

--- a/src/elements/pill.svelte
+++ b/src/elements/pill.svelte
@@ -2,15 +2,21 @@
 
 <script lang='ts'>
 
+import cx from 'classnames';
 import { dispatcher } from '../lib/dispatch';
 import { addStyles } from '../lib/index';
 import { htmlToBoolean } from '../lib/boolean';
 
 export let value = ''; 
 export let removable = 'true';
+export let readonly: string;
+export let disabled: string;
+let isReadonly: boolean;
+let isDisabled: boolean;
 let isRemovable: boolean;
 $: isRemovable = htmlToBoolean(removable, 'removable');
-
+$: isReadonly = htmlToBoolean(readonly, 'readonly');
+$: isDisabled = htmlToBoolean(disabled, 'disabled');
 
 const dispatch = dispatcher();
 addStyles();
@@ -22,7 +28,9 @@ const handleRemove = () => {
 </script>
 
 
-<div class='flex items-center max-w-fit gap-1 rounded-xl bg-[#C4C4C4] py-0.5 px-2 text-[10px] hover:bg-gray-300'>
+<div class={cx('flex items-center max-w-fit gap-1 rounded-xl bg-[#C4C4C4] py-0.5 px-2 text-[10px] hover:bg-gray-300', {
+  'bg-black/20': isDisabled || isReadonly
+})}>
   <span>
     {value}
   </span>

--- a/src/elements/pill.svelte
+++ b/src/elements/pill.svelte
@@ -29,7 +29,7 @@ const handleRemove = () => {
 
 
 <div class={cx('flex items-center max-w-fit gap-1 rounded-xl bg-[#C4C4C4] py-0.5 px-2 text-[10px] hover:bg-gray-300', {
-  'bg-black/20': isDisabled || isReadonly
+  'bg-black/20': isDisabled || isReadonly,
 })}>
   <span>
     {value}

--- a/src/elements/radio.svelte
+++ b/src/elements/radio.svelte
@@ -7,6 +7,7 @@ type LabelPosition = 'top' | 'left'
 import cx from 'classnames';
 import { addStyles } from '../lib/index';
 import { dispatcher } from '../lib/dispatch';
+import { htmlToBoolean } from '../lib/boolean';
 
 export let label = '';
 export let options = '';
@@ -14,17 +15,22 @@ export let selected = '';
 export let labelposition: LabelPosition = 'top';
 export let tooltip = '';
 export let state: 'info' | 'warn' | 'error' | '' = 'info';
+export let readonly: string;
 
 const dispatch = dispatcher();
 
 addStyles();
 
 let parsedOptions: string[];
+let isReadonly: boolean;
 $: parsedOptions = options.split(',').map((str) => str.trim());
+$: isReadonly = htmlToBoolean(readonly, 'readonly');
 
 const handleClick = (value: string) => {
-  selected = value;
-  dispatch('input', { value });
+  if(!isReadonly){
+    selected = value;
+    dispatch('input', { value });
+  }
 };
 
 </script>
@@ -37,6 +43,7 @@ const handleClick = (value: string) => {
     {#if label}
       <p class={cx('text-xs', {
         inline: labelposition === 'left',
+        'opacity-75 pointer-events-none': isReadonly,
       })}>
         {label}
       </p>
@@ -59,6 +66,7 @@ const handleClick = (value: string) => {
         class={cx('whitespace-nowrap capitalize border-y border-l last:border-r border-black px-2 py-1 text-xs', {
           'bg-white': option !== selected,
           'bg-black text-white': option === selected,
+          'opacity-75 pointer-events-none': isReadonly,
         })}
         on:click={() => handleClick(option)}
       >

--- a/src/elements/radio.svelte
+++ b/src/elements/radio.svelte
@@ -27,7 +27,7 @@ $: parsedOptions = options.split(',').map((str) => str.trim());
 $: isReadonly = htmlToBoolean(readonly, 'readonly');
 
 const handleClick = (value: string) => {
-  if(!isReadonly){
+  if (!isReadonly) {
     selected = value;
     dispatch('input', { value });
   }
@@ -68,7 +68,7 @@ const handleClick = (value: string) => {
           'bg-black text-white font-bold': ((option === selected) && !isReadonly),
           'bg-black/20 text-black/50 font-bold': ((option === selected) && isReadonly),
           'border-black/50 text-black/50 ': isReadonly,
-          'cursor-not-allowed pointer-events-none': isReadonly
+          'cursor-not-allowed pointer-events-none': isReadonly,
         })}
         on:click={() => handleClick(option)}
       >

--- a/src/elements/radio.svelte
+++ b/src/elements/radio.svelte
@@ -43,7 +43,7 @@ const handleClick = (value: string) => {
     {#if label}
       <p class={cx('text-xs', {
         inline: labelposition === 'left',
-        'opacity-75 pointer-events-none': isReadonly,
+        'text-black/50': isReadonly,
       })}>
         {label}
       </p>
@@ -65,8 +65,10 @@ const handleClick = (value: string) => {
       <button
         class={cx('whitespace-nowrap capitalize border-y border-l last:border-r border-black px-2 py-1 text-xs', {
           'bg-white': option !== selected,
-          'bg-black text-white': option === selected,
-          'opacity-75 pointer-events-none': isReadonly,
+          'bg-black text-white font-bold': ((option === selected) && !isReadonly),
+          'bg-black/20 text-black/50 font-bold': ((option === selected) && isReadonly),
+          'border-black/50 text-black/50 ': isReadonly,
+          'cursor-not-allowed pointer-events-none': isReadonly
         })}
         on:click={() => handleClick(option)}
       >

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -188,9 +188,11 @@ const handleIconClick = () => {
 };
 
 const handlePillClick = (target: string) => {
-  const newValue = parsedSelected.filter((item: string) => item !== target);
-  value = newValue.toString();
-  dispatch('input', { value, values: newValue, removed: target });
+  if(!isReadonly){
+    const newValue = parsedSelected.filter((item: string) => item !== target);
+    value = newValue.toString();
+    dispatch('input', { value, values: newValue, removed: target });
+  }
 };
 
 const handleOptionMouseEnter = (index: number) => {
@@ -264,8 +266,7 @@ $: {
     <div class='flex items-center gap-1.5'>
       {#if label}
         <p class={cx('text-xs capitalize', {
-          'opacity-50 pointer-events-none': isDisabled,
-          'opacity-75 pointer-events-none': isReadonly,
+          'text-black/50': isDisabled|| isReadonly,
           'inline whitespace-nowrap': labelposition === 'left',
         })}>
           {label}
@@ -291,8 +292,7 @@ $: {
       <div
         slot='target'
         class={cx('w-full border border-black bg-white', {
-          'opacity-50 pointer-events-none bg-gray-200': isDisabled,
-          'opacity-75 pointer-events-none bg-gray-200': isReadonly,
+          'border-black/50': isDisabled || isReadonly
         })}
       >
         <div class='flex'>
@@ -310,7 +310,10 @@ $: {
           <button
             tabindex='-1'
             aria-label='Open dropdown'
-            class={cx('py-1.5 px-1 grid place-content-center transition-transform duration-200', { 'rotate-180': open })}
+            class={cx('py-1.5 px-1 grid place-content-center transition-transform duration-200', { 
+              'rotate-180': open,
+              'text-black/50': isDisabled || isReadonly
+            })}
             on:click={handleIconClick}
             on:focusin|stopPropagation
           >
@@ -415,11 +418,16 @@ $: {
     </v-dropdown>
   </label>
   {#if parsedSelected.length > 0 && showsPill}
-    <div class='flex flex-wrap gap-2 pt-2'>
+    <div class={cx('flex flex-wrap gap-2 pt-2', {
+      'cursor-not-allowed pointer-events-none': isDisabled || isReadonly,
+      'text-black/50' : isDisabled || isReadonly
+    })}>
       {#each parsedSelected as option (option)}
         <v-pill
           on:remove={() => handlePillClick(option)}
           value={option}
+          {readonly}
+          {disabled}
         />
       {/each}
     </div>

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -18,6 +18,7 @@ export let placeholder = '';
 export let label = '';
 export let labelposition: LabelPosition = 'top';
 export let disabled = 'false';
+export let readonly: string;
 export let prefix = 'false';
 export let tooltip = '';
 export let state: 'info' | 'warn' | 'error' | '' = 'info';
@@ -38,6 +39,7 @@ let root: HTMLElement;
 let input: HTMLInputElement;
 let optionsContainer: HTMLElement;
 let isDisabled: boolean;
+let isReadonly: boolean;
 let hasPrefix: boolean;
 let showsPill: boolean;
 let canClearAll: boolean;
@@ -51,6 +53,7 @@ let searchedOptions: { option: string; search?: string[] }[];
 
 
 $: isDisabled = htmlToBoolean(disabled, 'disabled');
+$: isReadonly = htmlToBoolean(readonly, 'readonly');
 $: hasPrefix = htmlToBoolean(prefix, 'prefix');
 $: showsPill = htmlToBoolean(showpill, 'showpill');
 $: canClearAll = htmlToBoolean(clearable, 'clearable');
@@ -161,7 +164,7 @@ const handleEscape = () => {
 };
 
 const handleFocus = () => {
-  if (open || isDisabled) {
+  if (open || isDisabled || isReadonly) {
     return;
   }
 
@@ -262,6 +265,7 @@ $: {
       {#if label}
         <p class={cx('text-xs capitalize', {
           'opacity-50 pointer-events-none': isDisabled,
+          'opacity-75 pointer-events-none': isReadonly,
           'inline whitespace-nowrap': labelposition === 'left',
         })}>
           {label}
@@ -288,6 +292,7 @@ $: {
         slot='target'
         class={cx('w-full border border-black bg-white', {
           'opacity-50 pointer-events-none bg-gray-200': isDisabled,
+          'opacity-75 pointer-events-none bg-gray-200': isReadonly,
         })}
       >
         <div class='flex'>
@@ -295,7 +300,7 @@ $: {
             bind:this={input}
             {placeholder}
             value={searchterm}
-            readonly={isDisabled ? true : undefined}
+            readonly={(isDisabled || isReadonly) ? true : undefined}
             aria-disabled={isDisabled ? true : undefined}
             type='text'
             class='py-1.5 pl-2.5 pr-1 grow text-xs border-0 outline-none bg-transparent appearance-none'

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -188,7 +188,7 @@ const handleIconClick = () => {
 };
 
 const handlePillClick = (target: string) => {
-  if(!isReadonly){
+  if (!isReadonly) {
     const newValue = parsedSelected.filter((item: string) => item !== target);
     value = newValue.toString();
     dispatch('input', { value, values: newValue, removed: target });
@@ -266,7 +266,7 @@ $: {
     <div class='flex items-center gap-1.5'>
       {#if label}
         <p class={cx('text-xs capitalize', {
-          'text-black/50': isDisabled|| isReadonly,
+          'text-black/50': isDisabled || isReadonly,
           'inline whitespace-nowrap': labelposition === 'left',
         })}>
           {label}
@@ -292,7 +292,7 @@ $: {
       <div
         slot='target'
         class={cx('w-full border border-black bg-white', {
-          'border-black/50': isDisabled || isReadonly
+          'border-black/50': isDisabled || isReadonly,
         })}
       >
         <div class='flex'>
@@ -312,7 +312,7 @@ $: {
             aria-label='Open dropdown'
             class={cx('py-1.5 px-1 grid place-content-center transition-transform duration-200', { 
               'rotate-180': open,
-              'text-black/50': isDisabled || isReadonly
+              'text-black/50': isDisabled || isReadonly,
             })}
             on:click={handleIconClick}
             on:focusin|stopPropagation
@@ -420,7 +420,7 @@ $: {
   {#if parsedSelected.length > 0 && showsPill}
     <div class={cx('flex flex-wrap gap-2 pt-2', {
       'cursor-not-allowed pointer-events-none': isDisabled || isReadonly,
-      'text-black/50' : isDisabled || isReadonly
+      'text-black/50': isDisabled || isReadonly,
     })}>
       {#each parsedSelected as option (option)}
         <v-pill

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -235,7 +235,7 @@ $: {
     <div
       slot='target'
       class={cx('w-full border border-black bg-white', {
-        'border-black/50': isDisabled || isReadonly
+        'border-black/50': isDisabled || isReadonly,
       })}
     >
       <div class='flex'>
@@ -247,7 +247,7 @@ $: {
           readonly={(isDisabled || isReadonly) ? true : undefined}
           type='text'
           class={cx('py-1.5 pl-2.5 pr-1 grow text-xs border-0 bg-transparent outline-none appearance-none', {
-            'text-black/50': isDisabled || isReadonly
+            'text-black/50': isDisabled || isReadonly,
           })}
           on:input|preventDefault={handleInput}
           on:keyup|stopPropagation|preventDefault={handleKeyUp}
@@ -257,7 +257,7 @@ $: {
           aria-label='Open dropdown'
           class={cx('py-1.5 px-1 grid place-content-center transition-transform duration-200', { 
             'rotate-180': open,
-            'text-black/50': isDisabled || isReadonly
+            'text-black/50': isDisabled || isReadonly,
           })}
           on:click={handleIconClick}
           on:focusin|stopPropagation

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -18,6 +18,7 @@ export let placeholder = '';
 export let label: string;
 export let labelposition: LabelPosition = 'top';
 export let disabled: string;
+export let readonly: string;
 export let exact = 'false';
 export let prefix = 'false';
 export let tooltip = '';
@@ -35,6 +36,7 @@ let root: HTMLElement;
 let input: HTMLInputElement;
 let optionsContainer: HTMLElement;
 let isDisabled: boolean;
+let isReadonly: boolean;
 let isExact: boolean;
 let hasPrefix: boolean;
 let hasButton: boolean;
@@ -45,6 +47,7 @@ let sortedOptions: string[];
 let searchedOptions: { option: string; search?: string[] }[];
 
 $: isDisabled = htmlToBoolean(disabled, 'disabled');
+$: isReadonly = htmlToBoolean(readonly, 'readonly');
 $: isExact = htmlToBoolean(exact, 'exact');
 $: hasPrefix = htmlToBoolean(prefix, 'prefix');
 $: hasButton = htmlToBoolean(withbutton, 'withbutton');
@@ -144,7 +147,7 @@ const handleEscape = () => {
 };
 
 const handleFocus = () => {
-  if (open || isDisabled) {
+  if (open || isDisabled || isReadonly) {
     return;
   }
 
@@ -208,6 +211,7 @@ $: {
     {#if label}
       <p class={cx('text-xs capitalize', {
         'opacity-50 pointer-events-none': isDisabled,
+        'opacity-75 pointer-events-none': isReadonly,
         'inline whitespace-nowrap': labelposition === 'left',
       })}>
         {label}
@@ -233,6 +237,7 @@ $: {
       slot='target'
       class={cx('w-full border border-black bg-white', {
         'opacity-50 pointer-events-none bg-gray-200': isDisabled,
+        'opacity-75 pointer-events-none bg-gray-200': isReadonly,
       })}
     >
       <div class='flex'>
@@ -241,7 +246,7 @@ $: {
           {placeholder}
           value={value}
           aria-disabled={isDisabled ? true : undefined}
-          readonly={isDisabled ? true : undefined}
+          readonly={(isDisabled || isReadonly) ? true : undefined}
           type='text'
           class='py-1.5 pl-2.5 pr-1 grow text-xs border-0 bg-transparent outline-none appearance-none'
           on:input|preventDefault={handleInput}

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -210,8 +210,7 @@ $: {
   <div class='flex items-center gap-1.5'>
     {#if label}
       <p class={cx('text-xs capitalize', {
-        'opacity-50 pointer-events-none': isDisabled,
-        'opacity-75 pointer-events-none': isReadonly,
+        'text-black/50': isDisabled || isReadonly,
         'inline whitespace-nowrap': labelposition === 'left',
       })}>
         {label}
@@ -236,8 +235,7 @@ $: {
     <div
       slot='target'
       class={cx('w-full border border-black bg-white', {
-        'opacity-50 pointer-events-none bg-gray-200': isDisabled,
-        'opacity-75 pointer-events-none bg-gray-200': isReadonly,
+        'border-black/50': isDisabled || isReadonly
       })}
     >
       <div class='flex'>
@@ -248,14 +246,19 @@ $: {
           aria-disabled={isDisabled ? true : undefined}
           readonly={(isDisabled || isReadonly) ? true : undefined}
           type='text'
-          class='py-1.5 pl-2.5 pr-1 grow text-xs border-0 bg-transparent outline-none appearance-none'
+          class={cx('py-1.5 pl-2.5 pr-1 grow text-xs border-0 bg-transparent outline-none appearance-none', {
+            'text-black/50': isDisabled || isReadonly
+          })}
           on:input|preventDefault={handleInput}
           on:keyup|stopPropagation|preventDefault={handleKeyUp}
         >
         <button
           tabindex='-1'
           aria-label='Open dropdown'
-          class={cx('py-1.5 px-1 grid place-content-center transition-transform duration-200', { 'rotate-180': open })}
+          class={cx('py-1.5 px-1 grid place-content-center transition-transform duration-200', { 
+            'rotate-180': open,
+            'text-black/50': isDisabled || isReadonly
+          })}
           on:click={handleIconClick}
           on:focusin|stopPropagation
         >

--- a/src/elements/slider.svelte
+++ b/src/elements/slider.svelte
@@ -455,7 +455,7 @@ const onChange = () => {
         aria-valuenow={value}
         aria-valuetext={value?.toString()}
         aria-orientation='horizontal'
-        aria-disabled={disabled}
+        aria-disabled={isDisabled ? true : undefined}
         tabindex='{ disabled ? -1 : 0 }'
       > 
 

--- a/src/elements/slider.svelte
+++ b/src/elements/slider.svelte
@@ -418,14 +418,17 @@ const onChange = () => {
 <!-- svelte-ignore a11y-label-has-associated-control -->
 <label class='flex flex-col gap-2'>
   {#if label}
-    <p class='text-xs capitalize'>{label}</p>
+    <p class={cn('text-xs capitalize', {
+      'text-black/50': isDisabled || isReadonly
+    })}>
+      {label}
+    </p>
   {/if}
 
   <div
     bind:this={slider}
     class={cn('slider relative h-0.5 mt-7 transition-opacity duration-200 select-none bg-black/50', {
-      'opacity-50': isDisabled,
-      'opacity-75': isReadonly,
+      'bg-black/20 text-black/50': isDisabled || isReadonly,
     })}
     class:range
     class:focus
@@ -458,13 +461,17 @@ const onChange = () => {
 
         <span class='handle-bg absolute left-0 bottom-1 rounded-full opacity-50 h-full w-full transition-transform bg-gray-400' />
 
-        <span class='absolute left-0 bottom-1 block rounded-full h-full w-full border border-black bg-white' />
+        <span class={cn('absolute left-0 bottom-1 block rounded-full h-full w-full border border-black bg-white', {
+          'border-black/50': isDisabled || isReadonly
+        })} />
 
         <span class={cn(
           'floating block absolute left-1/2 bottom-full -translate-x-1/2 -translate-y-1/2',
           'py-1 px-1.5 text-center opacity-0 pointer-events-none whitespace-nowrap transition duration-200 border border-black bg-white text-xs',
           {
             '-translate-y-1.5': !focus || activeHandle !== index,
+            'border-black/50': isDisabled || isReadonly,
+            'text-black/50': isDisabled || isReadonly
           }
         )}>
           {value}
@@ -478,7 +485,9 @@ const onChange = () => {
 
     {#if range}
       <span
-        class='absolute block transition duration-200 h-1 -top-0.5 select-none z-[1] bg-black'
+        class={cn('absolute block transition duration-200 h-1 -top-0.5 select-none z-[1] bg-black', {
+          'bg-black/50': isDisabled || isReadonly,
+        })}
         style='left: {rangeStart($springPositions)}%; right: {rangeEnd($springPositions)}%'
       />
     {/if}
@@ -500,7 +509,9 @@ const onChange = () => {
         {#each Array.from({ length: pipCount + 1 }) as _, i}
           {#if pipVal(i) !== minNum && pipVal(i) !== maxNum}
             <span
-              class='absolute h-[4px] w-[1px] top-[calc(50%-9px)] whitespace-nowrap transition bg-black/50'
+              class={cn('absolute h-[4px] w-[1px] top-[calc(50%-9px)] whitespace-nowrap transition bg-black/50', {
+                'bg-black/20': isDisabled || isReadonly
+              })}
               style='left: {percentOf(pipVal(i), minNum, maxNum, 2)}%;'
             />
           {/if}

--- a/src/elements/slider.svelte
+++ b/src/elements/slider.svelte
@@ -40,7 +40,7 @@ let endValue: number | undefined;
 let pipStep: number;
 let pipCount: number;
 let isReadonly: boolean;
-let isDisabled: boolean
+let isDisabled: boolean;
 
 $: isReadonly = htmlToBoolean(readonly, 'readonly');
 $: isDisabled = htmlToBoolean(disabled, 'disabled');
@@ -419,7 +419,7 @@ const onChange = () => {
 <label class='flex flex-col gap-2'>
   {#if label}
     <p class={cn('text-xs capitalize', {
-      'text-black/50': isDisabled || isReadonly
+      'text-black/50': isDisabled || isReadonly,
     })}>
       {label}
     </p>
@@ -462,7 +462,7 @@ const onChange = () => {
         <span class='handle-bg absolute left-0 bottom-1 rounded-full opacity-50 h-full w-full transition-transform bg-gray-400' />
 
         <span class={cn('absolute left-0 bottom-1 block rounded-full h-full w-full border border-black bg-white', {
-          'border-black/50': isDisabled || isReadonly
+          'border-black/50': isDisabled || isReadonly,
         })} />
 
         <span class={cn(
@@ -471,7 +471,7 @@ const onChange = () => {
           {
             '-translate-y-1.5': !focus || activeHandle !== index,
             'border-black/50': isDisabled || isReadonly,
-            'text-black/50': isDisabled || isReadonly
+            'text-black/50': isDisabled || isReadonly,
           }
         )}>
           {value}
@@ -510,7 +510,7 @@ const onChange = () => {
           {#if pipVal(i) !== minNum && pipVal(i) !== maxNum}
             <span
               class={cn('absolute h-[4px] w-[1px] top-[calc(50%-9px)] whitespace-nowrap transition bg-black/50', {
-                'bg-black/20': isDisabled || isReadonly
+                'bg-black/20': isDisabled || isReadonly,
               })}
               style='left: {percentOf(pipVal(i), minNum, maxNum, 2)}%;'
             />

--- a/src/elements/slider.svelte
+++ b/src/elements/slider.svelte
@@ -417,7 +417,7 @@ const onChange = () => {
 
   <div
     bind:this={slider}
-    class={cn('slider relative h-0.5 mt-7 transition-opacity duration-200 select-none pip-labels bg-black/50', {
+    class={cn('slider relative h-0.5 mt-7 transition-opacity duration-200 select-none bg-black/50', {
       'opacity-50': disabled,
     })}
     class:range
@@ -455,7 +455,7 @@ const onChange = () => {
 
         <span class={cn(
           'floating block absolute left-1/2 bottom-full -translate-x-1/2 -translate-y-1/2',
-          'py-1 px-1.5 text-sm text-center opacity-0 pointer-events-none whitespace-nowrap transition duration-200 border border-black bg-white text-xs',
+          'py-1 px-1.5 text-center opacity-0 pointer-events-none whitespace-nowrap transition duration-200 border border-black bg-white text-xs',
           {
             '-translate-y-1.5': !focus || activeHandle !== index,
           }
@@ -481,11 +481,11 @@ const onChange = () => {
       class:disabled
       class:focus 
     >
-      <small class='absolute bottom-full left-0 -translate-x-1/2 mb-3 whitespace-nowrap text-xs'>
+      <small class='absolute bottom-full left-0 mb-3 whitespace-nowrap text-xs'>
         {minNum}
         
         {#if suffix}
-          <span class='pipVal-suffix'>{suffix}</span>
+          <span>{suffix}</span>
         {/if}
       </small>
 
@@ -500,11 +500,11 @@ const onChange = () => {
         {/each}
       {/if}
 
-      <small class='absolute bottom-full right-0 translate-x-1/2 mb-3 whitespace-nowrap text-xs'>
+      <small class='absolute bottom-full right-0 mb-3 whitespace-nowrap text-xs'>
         {maxNum}
         
         {#if suffix}
-          <span class='pipVal-suffix'>{suffix}</span>
+          <span>{suffix}</span>
         {/if}
       </small>
 

--- a/src/elements/switch.svelte
+++ b/src/elements/switch.svelte
@@ -12,6 +12,7 @@ export let name = '';
 export let value: 'on' | 'off' = 'off';
 export let variant: 'annotated' | 'default' = 'default';
 export let disabled: string;
+export let readonly: string;
 export let labelposition: 'left' | 'top' = 'top';
 export let tooltip = '';
 
@@ -22,9 +23,11 @@ addStyles();
 let input: HTMLInputElement;
 let on: boolean;
 let isDisabled: boolean;
+let isReadonly: boolean;
 
 $: on = value === 'on';
 $: isDisabled = htmlToBoolean(disabled, 'disabled');
+$: isReadonly = htmlToBoolean(readonly, 'readonly');
 
 const handleClick = () => { 
   value = (on) ? 'off' : 'on';
@@ -39,6 +42,7 @@ const handleClick = () => {
     'flex-col justify-start': labelposition === 'top',
     'items-center': labelposition === 'left',
     'opacity-50 pointer-events-none': isDisabled,
+    'opacity-75 pointer-events-none': isReadonly,
   })}
 >
 <div class='flex items-center gap-1.5'>
@@ -82,6 +86,7 @@ const handleClick = () => {
         {name}
         {value}
         disabled={isDisabled}
+        readonly={(isDisabled || isReadonly) ? true : undefined}
         class='hidden'
         type='checkbox'
         checked={on}

--- a/src/elements/switch.svelte
+++ b/src/elements/switch.svelte
@@ -30,9 +30,11 @@ $: isDisabled = htmlToBoolean(disabled, 'disabled');
 $: isReadonly = htmlToBoolean(readonly, 'readonly');
 
 const handleClick = () => { 
-  value = (on) ? 'off' : 'on';
-  input.checked = value === 'on';
-  dispatch('input', { value: input.checked });
+  if(!(isDisabled || isReadonly)){
+    value = (on) ? 'off' : 'on';
+    input.checked = value === 'on';
+    dispatch('input', { value: input.checked });
+  }
 };
 
 </script>
@@ -41,8 +43,7 @@ const handleClick = () => {
   class={cx('flex gap-1', {
     'flex-col justify-start': labelposition === 'top',
     'items-center': labelposition === 'left',
-    'opacity-50 pointer-events-none': isDisabled,
-    'opacity-75 pointer-events-none': isReadonly,
+    'text-black/50': isDisabled || isReadonly,
   })}
 >
 <div class='flex items-center gap-1.5'>
@@ -56,7 +57,7 @@ const handleClick = () => {
 
   {#if tooltip}
   <v-tooltip text={tooltip}>
-    <div class="icon-info-outline text-black" />
+    <div class="icon-info-outline text-black"/>
   </v-tooltip>
   {/if}
 </div>
@@ -65,7 +66,9 @@ const handleClick = () => {
   <button
     on:click={handleClick}
     type='button'
-    class='flex gap-1.5 items-center'
+    class={cx('flex gap-1.5 items-center', {
+      'cursor-not-allowed pointer-events-none': isDisabled || isReadonly
+    })}
     role='switch'
     aria-label={label}
     aria-disabled={isDisabled}
@@ -73,12 +76,15 @@ const handleClick = () => {
   >
     <div
       class={cx('relative inline-flex flex-shrink-0 h-5 w-11 border border-black/70 cursor-pointer motion-safe:transition-colors ease-in-out duration-200 focus:outline-none', {
+        'bg-black/20 border-black/40': isDisabled || isReadonly,
         'bg-black/50': !on,
         'bg-green/80': on,
       })}
     >
       <span
-        class='pointer-events-none relative inline-block border border-green/100 h-4 w-4 mt-px ml-px bg-white shadow transform ring-0 motion-safe:transition-transform ease-in-out duration-200'
+        class={cx('pointer-events-none relative inline-block border border-green/100 h-4 w-4 mt-px ml-px bg-white shadow transform ring-0 motion-safe:transition-transform ease-in-out duration-200', {
+          'border-black/40': isDisabled || isReadonly
+        })}
         class:translate-x-0={!on}
         class:translate-x-6={on}
       />

--- a/src/elements/switch.svelte
+++ b/src/elements/switch.svelte
@@ -30,7 +30,7 @@ $: isDisabled = htmlToBoolean(disabled, 'disabled');
 $: isReadonly = htmlToBoolean(readonly, 'readonly');
 
 const handleClick = () => { 
-  if(!(isDisabled || isReadonly)){
+  if (!(isDisabled || isReadonly)) {
     value = (on) ? 'off' : 'on';
     input.checked = value === 'on';
     dispatch('input', { value: input.checked });
@@ -67,7 +67,7 @@ const handleClick = () => {
     on:click={handleClick}
     type='button'
     class={cx('flex gap-1.5 items-center', {
-      'cursor-not-allowed pointer-events-none': isDisabled || isReadonly
+      'cursor-not-allowed pointer-events-none': isDisabled || isReadonly,
     })}
     role='switch'
     aria-label={label}
@@ -83,7 +83,7 @@ const handleClick = () => {
     >
       <span
         class={cx('pointer-events-none relative inline-block border border-green/100 h-4 w-4 mt-px ml-px bg-white shadow transform ring-0 motion-safe:transition-transform ease-in-out duration-200', {
-          'border-black/40': isDisabled || isReadonly
+          'border-black/40': isDisabled || isReadonly,
         })}
         class:translate-x-0={!on}
         class:translate-x-6={on}

--- a/src/stories/multiselect.stories.mdx
+++ b/src/stories/multiselect.stories.mdx
@@ -238,6 +238,31 @@ Dropdown that allows the user to select multiple choices.
   </Story>
 </Canvas>
 
+<Canvas>
+  <Story
+    name='Readonly'
+    args={{
+      label: 'Your options',
+      options: 'Option 1, Option 2, Option 3',
+      readonly: 'true',
+      tooltip: 'This is readonly.',
+      state: 'warn',
+      value: 'Option 1'
+    }}
+  >
+    {({ label, options, readonly, tooltip, state, value }) => `
+      <v-multiselect
+        label='${label}'
+        options='${options}'
+        readonly='${readonly}'
+        tooltip='${tooltip}'
+        state='${state}'
+        value='${value}'
+      />
+    `}
+  </Story>
+</Canvas>
+
 
 <Canvas>
   <Story

--- a/src/stories/multiselect.stories.mdx
+++ b/src/stories/multiselect.stories.mdx
@@ -245,18 +245,14 @@ Dropdown that allows the user to select multiple choices.
       label: 'Your options',
       options: 'Option 1, Option 2, Option 3',
       readonly: 'true',
-      tooltip: 'This is readonly.',
-      state: 'warn',
-      value: 'Option 1'
+      value: 'Option 1, Option 2'
     }}
   >
-    {({ label, options, readonly, tooltip, state, value }) => `
+    {({ label, options, readonly, value }) => `
       <v-multiselect
         label='${label}'
         options='${options}'
         readonly='${readonly}'
-        tooltip='${tooltip}'
-        state='${state}'
         value='${value}'
       />
     `}

--- a/src/stories/radio.stories.mdx
+++ b/src/stories/radio.stories.mdx
@@ -88,3 +88,22 @@ For user triggered actions
     `}
   </Story>
 </Canvas>
+
+<Canvas>
+  <Story
+    name='Readonly'
+    args={{
+      options: 'Opt 1, Opt 2, Opt 3',
+      selected: 'Opt 1',
+      readonly: 'true'
+    }}
+  >
+    {({ options, selected, readonly }) => `
+      <v-radio
+        options='${options}'
+        selected='${selected}'
+        readonly='${readonly}'
+      />
+    `}
+  </Story>
+</Canvas>

--- a/src/stories/select.stories.mdx
+++ b/src/stories/select.stories.mdx
@@ -184,6 +184,27 @@ For a dropdown that allows the user to select a single option
 
 <Canvas>
   <Story
+    name='Readonly'
+    args={{
+      label: 'Readonly',
+      options: 'Option 1, Option 2, Option 3',
+      readonly: 'readonly',
+      value: 'Option 1'
+    }}
+  >
+    {({ label, options, readonly, value }) => `
+      <v-select
+        label='${label}'
+        options='${options}'
+        readonly='${readonly}'
+        value='${value}'
+      />
+    `}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
     name='Exact'
     args={{
       label: 'Exact Option',

--- a/src/stories/slider.stories.mdx
+++ b/src/stories/slider.stories.mdx
@@ -215,3 +215,24 @@ For user triggered actions
     `}
   </Story>
 </Canvas>
+
+<Canvas>
+  <Story
+    name='Readonly'
+    args={{
+      min: 0,
+      max: 100,
+      step: 10,
+      readonly: true,
+    }}
+  >
+    {({ min, max, step, readonly }) => `
+      <v-slider
+        min='${min}'
+        max='${max}'
+        step='${step}'
+        readonly='${readonly}'
+      />
+    `}
+  </Story>
+</Canvas>

--- a/src/stories/slider.stories.mdx
+++ b/src/stories/slider.stories.mdx
@@ -220,18 +220,22 @@ For user triggered actions
   <Story
     name='Readonly'
     args={{
-      min: 0,
+      range: 'min',
       max: 100,
       step: 10,
-      readonly: true,
+      value: 30,
+      readonly: 'true',
+      label: 'readonly'
     }}
   >
-    {({ min, max, step, readonly }) => `
+    {({ range, max, step, value, readonly, label }) => `
       <v-slider
-        min='${min}'
+        range='${range}'
         max='${max}'
         step='${step}'
+        value='${value}'
         readonly='${readonly}'
+        label='${label}'
       />
     `}
   </Story>

--- a/src/stories/switch.stories.mdx
+++ b/src/stories/switch.stories.mdx
@@ -98,14 +98,16 @@ Used to handle binary input.
     args={{
       value: 'off',
       variant: 'labeled',
-      disabled: 'true'
+      disabled: 'true',
+      label: 'disabled',
     }}
   >
-    {({ value, variant, disabled }) => `
+    {({ value, variant, disabled, label }) => `
       <v-switch
         value='${value}'
         variant='${variant}'
         disabled='${disabled}'
+        label='${label}'
       />
     `}
   </Story>
@@ -136,16 +138,18 @@ Used to handle binary input.
   <Story
     name='Readonly'
     args={{
-      value: 'off',
+      value: 'on',
       variant: 'annotated',
-      readonly: 'true'
+      readonly: 'true',
+      label: 'readonly'
     }}
   >
-    {({ value, variant, readonly }) => `
+    {({ value, variant, readonly, label }) => `
       <v-switch
         value='${value}'
         variant='${variant}'
         readonly='${readonly}'
+        label='${label}'
       />
     `}
   </Story>

--- a/src/stories/switch.stories.mdx
+++ b/src/stories/switch.stories.mdx
@@ -131,3 +131,22 @@ Used to handle binary input.
     `}
   </Story>
 </Canvas>
+
+<Canvas>
+  <Story
+    name='Readonly'
+    args={{
+      value: 'off',
+      variant: 'annotated',
+      readonly: 'true'
+    }}
+  >
+    {({ value, variant, readonly }) => `
+      <v-switch
+        value='${value}'
+        variant='${variant}'
+        readonly='${readonly}'
+      />
+    `}
+  </Story>
+</Canvas>


### PR DESCRIPTION
I have gone through the PRIME elements added readonly states where they didn't exist on any element that the user can input information to. I have also changed all readonly and disabled states to look the same to user by changing the text and background colors, rather than the previous method of changing the opacity of the text and the background. Examples shown below.

input - readonly (top) and disabled (bottom):
<img width="1172" alt="Screenshot 2023-01-18 at 2 40 15 PM" src="https://user-images.githubusercontent.com/61131470/213278701-fa33a3b2-0cc5-4dca-8799-4566f46784c7.png">

multi-select - readonly (top) and disabled (bottom):
<img width="1174" alt="Screenshot 2023-01-18 at 2 40 38 PM" src="https://user-images.githubusercontent.com/61131470/213278710-191cbd14-6008-4270-8a02-419970632059.png">