### PR TITLE
APP-1268: Prime Breadcrumbs E2E Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/playground/src/Test.vue
+++ b/playground/src/Test.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 
+import BreadcrumbsTest from './breadcrumb-test.vue';
+
 </script>
 
 <template>
@@ -19,5 +21,8 @@
       options="Jolly logs, Sleeping hogs, Sticky bogs, Fiendish dogs"
       placeholder="Select a Bobbins"
     />
+
+  <BreadcrumbsTest />
+  
   </main>
 </template>

--- a/playground/src/breadcrumb-test.vue
+++ b/playground/src/breadcrumb-test.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+  <main class="m-3">
+    <v-breadcrumbs
+      data-testid="Breadcrumb Test"
+      crumbs="Chocolate Chip, Oatmeal Raisin"
+    />
+  </main>
+</template>

--- a/playground/src/breadcrumb-test.vue
+++ b/playground/src/breadcrumb-test.vue
@@ -5,7 +5,6 @@
 <template>
   <main class="m-3">
     <v-breadcrumbs
-      data-testid="Breadcrumb Test"
       crumbs="Chocolate Chip, Oatmeal Raisin"
     />
   </main>

--- a/tests/breadcrumbs.spec.ts
+++ b/tests/breadcrumbs.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('breadcrumbs should render the list of values as pills', async ({ page }) => {
+  await page.goto('/test.html');
+
+  // GIVEN a "crumbs" attribute has been applied to the v-breadcrumbs element
+  // AND the value passed to the "crumbs" attribute is a comma-separated list of strings
+  // WHEN the element is rendered
+  // THEN the breadcrumbs should render the list of values as pills
+
+  await expect(page.getByTestId("Breadcrumb Test")).toBeVisible()
+  await expect(page.getByText(/Chocolate Chip/i)).toBeVisible()
+  await expect(page.getByText(/Oatmeal Raisin/i)).toBeVisible()
+
+});
+

--- a/tests/breadcrumbs.spec.ts
+++ b/tests/breadcrumbs.spec.ts
@@ -8,7 +8,11 @@ test('breadcrumbs should render the list of values as pills', async ({ page }) =
   // WHEN the element is rendered
   // THEN the breadcrumbs should render the list of values as pills
 
-  await expect(page.getByTestId("Breadcrumb Test")).toBeVisible()
+  const breadcrumbs = page.getByText('Chocolate Chip Oatmeal Raisin')
+  await expect(breadcrumbs).toBeVisible()
+  await expect(breadcrumbs).toHaveCSS('border-color', 'rgb(0, 0, 0)')
+  await expect(breadcrumbs).toHaveCSS('border-radius', '9999px')
+  await expect(breadcrumbs).toHaveText('Chocolate Chip Oatmeal Raisin')
   await expect(page.getByText(/Chocolate Chip/i)).toBeVisible()
   await expect(page.getByText(/Oatmeal Raisin/i)).toBeVisible()
 

--- a/tests/breadcrumbs.spec.ts
+++ b/tests/breadcrumbs.spec.ts
@@ -10,8 +10,6 @@ test('breadcrumbs should render the list of values as pills', async ({ page }) =
 
   const breadcrumbs = page.getByText('Chocolate Chip Oatmeal Raisin')
   await expect(breadcrumbs).toBeVisible()
-  await expect(breadcrumbs).toHaveCSS('border-color', 'rgb(0, 0, 0)')
-  await expect(breadcrumbs).toHaveCSS('border-radius', '9999px')
   await expect(breadcrumbs).toHaveText('Chocolate Chip Oatmeal Raisin')
   await expect(page.getByText(/Chocolate Chip/i)).toBeVisible()
   await expect(page.getByText(/Oatmeal Raisin/i)).toBeVisible()


### PR DESCRIPTION
**2023.02.13_APP-1268: Prime Breadcrumbs E2E Tests**

**Items to Note:**

- This PR is comprised of playwright tests to confirm the following behavior for prime breadcrumbs.



Behavior | Scenario
-- | --
Crumbs | GIVEN a "crumbs" attribute has been applied to the v-breadcrumbs element AND the value passed to the "crumbs" attribute is a comma-separated list of strings WHEN the element is rendered THEN the breadcrumbs should render the list of values as pills

<p></p>
