### PR TITLE
APP-1270 - Icon e2e

### DIFF
--- a/playground/src/Test.vue
+++ b/playground/src/Test.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import BadgeTest from './badge-test.vue'
-import pillTest from'./pillTest.vue'
+import PillTest from'./pill-test.vue'
 import BreadcrumbsTest from './breadcrumb-test.vue';
+import IconTest from './icon-test.vue'
 
 </script>
 
@@ -35,7 +36,8 @@ import BreadcrumbsTest from './breadcrumb-test.vue';
       <div slot="left-empty">Your roster is empty</div>
       <div slot="right-empty">This box is empty</div>
     </v-list-box>
-    <pillTest/>
+    <PillTest/>
     <BreadcrumbsTest /> 
+    <IconTest />
   </main>
 </template>

--- a/playground/src/icon-test.vue
+++ b/playground/src/icon-test.vue
@@ -4,15 +4,15 @@
 
 <template>
     <main class="m-3">
-        <v-icon data-testid="default-valid" name='camera' />
-        <v-icon data-testid="default-invalid" name='invalidmoose' />
-        <v-icon data-testid="size-xs" name='camera' size='xs' />
-        <v-icon data-testid="size-sm" name='camera' size='sm' />
-        <v-icon data-testid="size-base" name='camera' size='base' />
-        <v-icon data-testid="size-lg" name='camera' size='lg' />
-        <v-icon data-testid="size-xl" name='camera' size='xl' />
-        <v-icon data-testid="size-2xl" name='camera' size='2xl' />
-        <v-icon data-testid="size-3xl" name='camera' size='3xl' />
-        <v-icon data-testid="size-4xl" name='camera' size='4xl' />
+        <v-icon data-testid="icon-default-valid" name='camera' />
+        <v-icon data-testid="icon-default-invalid" name='invalidmoose' />
+        <v-icon data-testid="icon-size-xs" name='camera' size='xs' />
+        <v-icon data-testid="icon-size-sm" name='camera' size='sm' />
+        <v-icon data-testid="icon-size-base" name='camera' size='base' />
+        <v-icon data-testid="icon-size-lg" name='camera' size='lg' />
+        <v-icon data-testid="icon-size-xl" name='camera' size='xl' />
+        <v-icon data-testid="icon-size-2xl" name='camera' size='2xl' />
+        <v-icon data-testid="icon-size-3xl" name='camera' size='3xl' />
+        <v-icon data-testid="icon-size-4xl" name='camera' size='4xl' />
     </main>
 </template>

--- a/playground/src/icon-test.vue
+++ b/playground/src/icon-test.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+    <main class="m-3">
+        <v-icon data-testid="default-valid" name='camera' />
+        <v-icon data-testid="default-invalid" name='invalidmoose' />
+        <v-icon data-testid="size-xs" name='camera' size='xs' />
+        <v-icon data-testid="size-sm" name='camera' size='sm' />
+        <v-icon data-testid="size-base" name='camera' size='base' />
+        <v-icon data-testid="size-lg" name='camera' size='lg' />
+        <v-icon data-testid="size-xl" name='camera' size='xl' />
+        <v-icon data-testid="size-2xl" name='camera' size='2xl' />
+        <v-icon data-testid="size-3xl" name='camera' size='3xl' />
+        <v-icon data-testid="size-4xl" name='camera' size='4xl' />
+    </main>
+</template>

--- a/playground/src/pill-test.vue
+++ b/playground/src/pill-test.vue
@@ -3,40 +3,38 @@
 </script>
 
 <template>
-  <main class="m-3">
     <v-pill
-      data-testid="default"
+      data-testid="pill-default"
     />
     <v-pill
-      data-testid="Value"
+      data-testid="pill-value"
       value='one'
     />
     <v-pill
-        data-testid="Removable:default"
+        data-testid="pill-removable-default"
     />
     <v-pill
-    data-testid="Removable:true"
+    data-testid="pill-removable-true"
       removable="true"
     />
     <v-pill
-    data-testid="Removable:false"
+    data-testid="pill-removable-false"
       removable="false"
     />
     <v-pill
-    data-testid="Disabled:true"
+    data-testid="pill-disabled-true"
     disabled="true"
     />
     <v-pill
-    data-testid="Disabled:false"
+    data-testid="pill-disabled-false"
     disabled="false"
     />
     <v-pill
-    data-testid="Readonly:true"
+    data-testid="pill-readonly-true"
     readonly="true"
     />
     <v-pill
-    data-testid="Readonly:false"
+    data-testid="pill-readonly-false"
     readonly="false"
     />
-  </main>
 </template>

--- a/playground/src/pill-test.vue
+++ b/playground/src/pill-test.vue
@@ -3,6 +3,7 @@
 </script>
 
 <template>
+  <main class="m-3">
     <v-pill
       data-testid="default"
     />
@@ -37,4 +38,5 @@
     data-testid="Readonly:false"
     readonly="false"
     />
+  </main>
 </template>

--- a/tests/Icon.spec.ts
+++ b/tests/Icon.spec.ts
@@ -4,31 +4,31 @@ test('Icons render as expected', async ({ page }) => {
     await page.goto('/test.html');
 
     // default valid
-    await expect(page.getByTestId("default-valid")).toBeVisible()
+    await expect(page.getByTestId("icon-default-valid")).toBeVisible()
     // default invalid
-    await expect(page.getByTestId("default-invalid")).not.toBeVisible()
+    await expect(page.getByTestId("icon-default-invalid")).not.toBeVisible()
     // size-xs
-    await expect(page.getByTestId("size-xs")).toBeVisible()
-    await expect(page.getByTestId("size-xs").locator('i')).toHaveClass(/text-xs/)
+    await expect(page.getByTestId("icon-size-xs")).toBeVisible()
+    await expect(page.getByTestId("icon-size-xs").locator('i')).toHaveClass(/text-xs/)
     // size-sm
-    await expect(page.getByTestId("size-sm")).toBeVisible()
-    await expect(page.getByTestId("size-sm").locator('i')).toHaveClass(/text-sm/)
+    await expect(page.getByTestId("icon-size-sm")).toBeVisible()
+    await expect(page.getByTestId("icon-size-sm").locator('i')).toHaveClass(/text-sm/)
     // size-base
-    await expect(page.getByTestId("size-base")).toBeVisible()
-    await expect(page.getByTestId("size-base").locator('i')).toHaveClass(/text-base/)
+    await expect(page.getByTestId("icon-size-base")).toBeVisible()
+    await expect(page.getByTestId("icon-size-base").locator('i')).toHaveClass(/text-base/)
     // size-lg
-    await expect(page.getByTestId("size-lg")).toBeVisible()
-    await expect(page.getByTestId("size-lg").locator('i')).toHaveClass(/text-lg/)
+    await expect(page.getByTestId("icon-size-lg")).toBeVisible()
+    await expect(page.getByTestId("icon-size-lg").locator('i')).toHaveClass(/text-lg/)
     // size-xl
-    await expect(page.getByTestId("size-xl")).toBeVisible()
-    await expect(page.getByTestId("size-xl").locator('i')).toHaveClass(/text-xl/)
+    await expect(page.getByTestId("icon-size-xl")).toBeVisible()
+    await expect(page.getByTestId("icon-size-xl").locator('i')).toHaveClass(/text-xl/)
     // size-2xl
-    await expect(page.getByTestId("size-2xl")).toBeVisible()
-    await expect(page.getByTestId("size-2xl").locator('i')).toHaveClass(/text-2xl/)
+    await expect(page.getByTestId("icon-size-2xl")).toBeVisible()
+    await expect(page.getByTestId("icon-size-2xl").locator('i')).toHaveClass(/text-2xl/)
     // size-3xl
-    await expect(page.getByTestId("size-3xl")).toBeVisible()
-    await expect(page.getByTestId("size-3xl").locator('i')).toHaveClass(/text-3xl/)
+    await expect(page.getByTestId("icon-size-3xl")).toBeVisible()
+    await expect(page.getByTestId("icon-size-3xl").locator('i')).toHaveClass(/text-3xl/)
     // size-4xl
-    await expect(page.getByTestId("size-4xl")).toBeVisible()
-    await expect(page.getByTestId("size-4xl").locator('i')).toHaveClass(/text-4xl/)
+    await expect(page.getByTestId("icon-size-4xl")).toBeVisible()
+    await expect(page.getByTestId("icon-size-4xl").locator('i')).toHaveClass(/text-4xl/)
 });

--- a/tests/Icon.spec.ts
+++ b/tests/Icon.spec.ts
@@ -8,19 +8,27 @@ test('Icons render as expected', async ({ page }) => {
     // default invalid
     await expect(page.getByTestId("default-invalid")).not.toBeVisible()
     // size-xs
+    await expect(page.getByTestId("size-xs")).toBeVisible()
     await expect(page.getByTestId("size-xs").locator('i')).toHaveClass(/text-xs/)
     // size-sm
+    await expect(page.getByTestId("size-sm")).toBeVisible()
     await expect(page.getByTestId("size-sm").locator('i')).toHaveClass(/text-sm/)
     // size-base
+    await expect(page.getByTestId("size-base")).toBeVisible()
     await expect(page.getByTestId("size-base").locator('i')).toHaveClass(/text-base/)
     // size-lg
+    await expect(page.getByTestId("size-lg")).toBeVisible()
     await expect(page.getByTestId("size-lg").locator('i')).toHaveClass(/text-lg/)
     // size-xl
+    await expect(page.getByTestId("size-xl")).toBeVisible()
     await expect(page.getByTestId("size-xl").locator('i')).toHaveClass(/text-xl/)
     // size-2xl
+    await expect(page.getByTestId("size-2xl")).toBeVisible()
     await expect(page.getByTestId("size-2xl").locator('i')).toHaveClass(/text-2xl/)
     // size-3xl
+    await expect(page.getByTestId("size-3xl")).toBeVisible()
     await expect(page.getByTestId("size-3xl").locator('i')).toHaveClass(/text-3xl/)
     // size-4xl
+    await expect(page.getByTestId("size-4xl")).toBeVisible()
     await expect(page.getByTestId("size-4xl").locator('i')).toHaveClass(/text-4xl/)
 });

--- a/tests/Icon.spec.ts
+++ b/tests/Icon.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from '@playwright/test';
+
+test('Icons render as expected', async ({ page }) => {
+    await page.goto('/test.html');
+
+    // default valid
+    await expect(page.getByTestId("default-valid")).toBeVisible()
+    // default invalid
+    await expect(page.getByTestId("default-invalid")).not.toBeVisible()
+    // size-xs
+    await expect(page.getByTestId("size-xs").locator('i')).toHaveClass(/text-xs/)
+    // size-sm
+    await expect(page.getByTestId("size-sm").locator('i')).toHaveClass(/text-sm/)
+    // size-base
+    await expect(page.getByTestId("size-base").locator('i')).toHaveClass(/text-base/)
+    // size-lg
+    await expect(page.getByTestId("size-lg").locator('i')).toHaveClass(/text-lg/)
+    // size-xl
+    await expect(page.getByTestId("size-xl").locator('i')).toHaveClass(/text-xl/)
+    // size-2xl
+    await expect(page.getByTestId("size-2xl").locator('i')).toHaveClass(/text-2xl/)
+    // size-3xl
+    await expect(page.getByTestId("size-3xl").locator('i')).toHaveClass(/text-3xl/)
+    // size-4xl
+    await expect(page.getByTestId("size-4xl").locator('i')).toHaveClass(/text-4xl/)
+});

--- a/tests/pill.spec.ts
+++ b/tests/pill.spec.ts
@@ -6,50 +6,50 @@ import {waitForCustomEvent, waitForCustomEventTimeout} from './lib/helper.ts'
 test('Pills render and interact as expected', async ({ page }) => {
     await page.goto('/test.html');
 
-    const testDefault = page.getByTestId("default")
-    const testReadOnly = page.getByTestId('Readonly:true')
-    const testDisabled = page.getByTestId("Disabled:true")
+    const testDefault = page.getByTestId("pill-default")
+    const testReadOnly = page.getByTestId('pill-readonly-true')
+    const testDisabled = page.getByTestId("pill-disabled-true")
 
     // Value
-    await expect(page.getByTestId("Value")).toBeVisible()
-    await expect(page.getByTestId("Value")).toContainText("one")
-    // Removable:default
+    await expect(page.getByTestId("pill-value")).toBeVisible()
+    await expect(page.getByTestId("pill-value")).toContainText("one")
+    // removable-default
     await expect(testDefault).toBeVisible()
     await expect(testDefault.getByRole('button')).toBeVisible()
-    // Removable:true
-    await expect(page.getByTestId("Removable:true")).toBeVisible()
-    await expect(page.getByTestId("Removable:true").getByRole('button')).toBeVisible()
-    // Removable:false
-    await expect(page.getByTestId("Removable:false")).toBeVisible()
-    await expect(page.getByTestId("Removable:false").getByRole('button')).toHaveCount(0)
-    // Disabled:default
+    // removable-true
+    await expect(page.getByTestId("pill-removable-true")).toBeVisible()
+    await expect(page.getByTestId("pill-removable-true").getByRole('button')).toBeVisible()
+    // removable-false
+    await expect(page.getByTestId("pill-removable-false")).toBeVisible()
+    await expect(page.getByTestId("pill-removable-false").getByRole('button')).toHaveCount(0)
+    // disabled-default
     await expect(testDefault).toBeVisible()
-    // Disabled:true
-    await expect(page.getByTestId("Disabled:true").locator("div")).toHaveAttribute("aria-disabled","true")
-    // Disabled:false
-    await expect(page.getByTestId("Disabled:false")).toBeVisible()
-    await expect(page.getByTestId("Disabled:false").locator("div")).not.toHaveAttribute("aria-readonly","true")
-    // Readonly:default
+    // disabled-true
+    await expect(page.getByTestId("pill-disabled-true").locator("div")).toHaveAttribute("aria-disabled","true")
+    // disabled-false
+    await expect(page.getByTestId("pill-disabled-false")).toBeVisible()
+    await expect(page.getByTestId("pill-disabled-false").locator("div")).not.toHaveAttribute("aria-readonly","true")
+    // readonly-default
     await expect(testDefault).toBeVisible()
     await expect(testDefault.getByRole('button')).toBeVisible()
-    // Readonly:true
-    await expect(page.getByTestId("Readonly:true")).toBeVisible()
-    await expect(page.getByTestId("Readonly:true").locator("div")).toHaveAttribute("aria-readonly","true")
-    // Readonly:false
-    await expect(page.getByTestId("Readonly:false")).toBeVisible()
-    await expect(page.getByTestId("Readonly:false").getByRole('button')).toBeVisible()
-    await expect(page.getByTestId("Readonly:false")).not.toHaveAttribute("aria-readonly","true")
+    // readonly-true
+    await expect(page.getByTestId("pill-readonly-true")).toBeVisible()
+    await expect(page.getByTestId("pill-readonly-true").locator("div")).toHaveAttribute("aria-readonly","true")
+    // readonly-false
+    await expect(page.getByTestId("pill-readonly-false")).toBeVisible()
+    await expect(page.getByTestId("pill-readonly-false").getByRole('button')).toBeVisible()
+    await expect(page.getByTestId("pill-readonly-false")).not.toHaveAttribute("aria-readonly","true")
     // Click:default
     const clickDefault = waitForCustomEvent(page,'remove')
     await testDefault.getByRole('button').click()
     await expect(clickDefault).toBeTruthy()
     // Click:disabled
     const clickDisabled = waitForCustomEventTimeout(page, 'remove')
-    await page.getByTestId("Disabled:true").getByRole('button').press("Enter")
+    await page.getByTestId("pill-disabled-true").getByRole('button').press("Enter")
     await clickDisabled
     // // Click:readonly
     const clickReadOnly = waitForCustomEventTimeout(page, 'remove')
-    await page.getByTestId("Readonly:true").getByRole('button').press("Enter")
+    await page.getByTestId("pill-readonly-true").getByRole('button').press("Enter")
     await clickReadOnly
     // // Key Down:default
     const keyDownDefault = waitForCustomEvent(page,'remove')
@@ -57,10 +57,10 @@ test('Pills render and interact as expected', async ({ page }) => {
     await expect(keyDownDefault).toBeTruthy()
     // // Key Down:disabled
     const keyDownDisabled = waitForCustomEventTimeout(page, 'remove')
-    await page.getByTestId("Disabled:true").getByRole('button').press("Enter")
+    await page.getByTestId("pill-disabled-true").getByRole('button').press("Enter")
     await keyDownDisabled
     // // Key Down:readonly
     const keyDownReadOnly = waitForCustomEventTimeout(page, 'remove')
-    await page.getByTestId("Readonly:true").getByRole('button').press("Enter")
+    await page.getByTestId("pill-readonly-true").getByRole('button').press("Enter")
     await keyDownReadOnly
 });


### PR DESCRIPTION
Add icon e2e tests. Also did some reformatting of test file names to keep them standardized.

Test cases covered:


Behavior | Scenario
-- | --
Name | GIVEN a "name" attribute has been applied to thev-icon elementAND the "name" attribute value is a valid icon nameWHEN the element is renderedTHEN the icon should render the appropriate image
Size: default | GIVEN a "size" attribute has not been applied to the v-icon elementWHEN the element is renderedTHEN the icon should render as the base size
Size: xs | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "xs"WHEN the element is renderedTHEN the icon should render as extra-small
Size: sm | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "sm"WHEN the element is renderedTHEN the icon should render as small
Size: base | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "base"WHEN the element is renderedTHEN the icon should render as the base size
Size: lg | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "lg"WHEN the element is renderedTHEN the icon should render as large
Size: xl | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "xl"WHEN the element is renderedTHEN the icon should render as extra-large
Size: 2xl | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "2xl"WHEN the element is renderedTHEN the icon should render as double-extra-large
Size: 3xl | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "3xl"WHEN the element is renderedTHEN the icon should render as triple-extra-large
Size: 4xl | GIVEN a "size" attribute has been applied to thev-icon elementAND the "size" attribute value is "4xl"WHEN the element is renderedTHEN the icon should render as quadruple-extra-large

