### PR TITLE
APP-1271 - Notify e2e

### DIFF
--- a/playground/src/Test.vue
+++ b/playground/src/Test.vue
@@ -2,6 +2,7 @@
 import BadgeTest from './badge-test.vue'
 import pillTest from'./pillTest.vue'
 import BreadcrumbsTest from './breadcrumb-test.vue';
+import NotifyTest from './notify-test.vue'
 
 </script>
 
@@ -37,5 +38,6 @@ import BreadcrumbsTest from './breadcrumb-test.vue';
     </v-list-box>
     <pillTest/>
     <BreadcrumbsTest /> 
+    <NotifyTest />
   </main>
 </template>

--- a/playground/src/notify-test.vue
+++ b/playground/src/notify-test.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+
+</script>
+
+<template>
+  <main>
+    <v-notify data-testid="notify-default" title='title text' message='message text'/>
+    <v-notify data-testid="notify-variant-error" title='title text' message='message text' variant="error"/>
+    <v-notify data-testid="notify-variant-warning" title='title text' message='message text' variant="warning"/>
+    <v-notify data-testid="notify-variant-success" title='title text' message='message text' variant="success"/>
+    <v-notify data-testid="notify-variant-info" title='title text' message='message text' variant="info"/>
+    <v-notify data-testid="notify-background-gray" title='title text' message='message text' background="gray"/>
+    <v-notify data-testid="notify-background-white" title='title text' message='message text' background="white"/>
+    <v-notify data-testid="notify-slot" title='title text' message="message text">slot text</v-notify>
+
+  </main>
+</template>
+
+<!-- Title
+Message
+Variant: default
+Variant: error
+Variant: warning
+Variant: success
+Variant: info
+Background: default
+Background: gray
+Background: white
+Slot -->

--- a/playground/src/notify-test.vue
+++ b/playground/src/notify-test.vue
@@ -12,18 +12,5 @@
     <v-notify data-testid="notify-background-gray" title='title text' message='message text' background="gray"/>
     <v-notify data-testid="notify-background-white" title='title text' message='message text' background="white"/>
     <v-notify data-testid="notify-slot" title='title text' message="message text">slot text</v-notify>
-
   </main>
 </template>
-
-<!-- Title
-Message
-Variant: default
-Variant: error
-Variant: warning
-Variant: success
-Variant: info
-Background: default
-Background: gray
-Background: white
-Slot -->

--- a/tests/notify.spec.ts
+++ b/tests/notify.spec.ts
@@ -51,9 +51,9 @@ test('Notify displays text properly', async ({ page }) => {
   await expect(page.getByTestId("notify-background-white")).toHaveText(/message text/)
   await expect(page.getByTestId("notify-background-white").locator("div")).toHaveClass(/bg-white/)
 
-    // slot
-    await expect(page.getByTestId("notify-slot")).toBeVisible()
-    await expect(page.getByTestId("notify-slot")).toHaveText(/title text/)
-    await expect(page.getByTestId("notify-slot")).toHaveText(/message text/)
-    await expect(page.getByTestId("notify-slot")).toHaveText(/slot text/)
+  // slot
+  await expect(page.getByTestId("notify-slot")).toBeVisible()
+  await expect(page.getByTestId("notify-slot")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-slot")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-slot")).toHaveText(/slot text/)
 });

--- a/tests/notify.spec.ts
+++ b/tests/notify.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+test('Notify displays text properly', async ({ page }) => {
+  await page.goto('/test.html');
+
+  //   default success
+  await expect(page.getByTestId("notify-default")).toBeVisible()
+  await expect(page.getByTestId("notify-default")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-default")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-default").locator("div")).toHaveClass(/border-blue/)
+  await expect(page.getByTestId("notify-default").locator("v-icon")).toHaveClass(/text-blue/)
+  await expect(page.getByTestId("notify-default").locator("div")).toHaveClass(/bg-gray/)
+
+  // variant error
+  await expect(page.getByTestId("notify-variant-error")).toBeVisible()
+  await expect(page.getByTestId("notify-variant-error")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-variant-error")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-variant-error").locator("div")).toHaveClass(/border-red/)
+  await expect(page.getByTestId("notify-variant-error").locator("v-icon")).toHaveClass(/text-red/)
+
+  // variant warning
+  await expect(page.getByTestId("notify-variant-warning")).toBeVisible()
+  await expect(page.getByTestId("notify-variant-warning")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-variant-warning")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-variant-warning").locator("div")).toHaveClass(/border-orange/)
+  await expect(page.getByTestId("notify-variant-warning").locator("path")).toHaveAttribute("fill","#FF9900")
+  
+  // variant success
+  await expect(page.getByTestId("notify-variant-success")).toBeVisible()
+  await expect(page.getByTestId("notify-variant-success")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-variant-success")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-variant-success").locator("div")).toHaveClass(/border-green/)
+  await expect(page.getByTestId("notify-variant-success").locator("v-icon")).toHaveClass(/text-green/)
+
+  // variant info
+  await expect(page.getByTestId("notify-variant-info")).toBeVisible()
+  await expect(page.getByTestId("notify-variant-info")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-variant-info")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-variant-info").locator("div")).toHaveClass(/border-blue/)
+  await expect(page.getByTestId("notify-variant-info").locator("v-icon")).toHaveClass(/text-blue/)
+
+  // background gray
+  await expect(page.getByTestId("notify-background-gray")).toBeVisible()
+  await expect(page.getByTestId("notify-background-gray")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-background-gray")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-background-gray").locator("div")).toHaveClass(/bg-gray/)
+
+  // background white
+  await expect(page.getByTestId("notify-background-white")).toBeVisible()
+  await expect(page.getByTestId("notify-background-white")).toHaveText(/title text/)
+  await expect(page.getByTestId("notify-background-white")).toHaveText(/message text/)
+  await expect(page.getByTestId("notify-background-white").locator("div")).toHaveClass(/bg-white/)
+
+    // slot
+    await expect(page.getByTestId("notify-slot")).toBeVisible()
+    await expect(page.getByTestId("notify-slot")).toHaveText(/title text/)
+    await expect(page.getByTestId("notify-slot")).toHaveText(/message text/)
+    await expect(page.getByTestId("notify-slot")).toHaveText(/slot text/)
+});


### PR DESCRIPTION
Add e2e tests for notify

Test cases:


Behavior | Scenario
-- | --
Title | GIVEN a "title" attribute has been applied to the v-notify elementWHEN the element is renderedTHEN the notify should render the "title" attribute value in the notify title
Message | GIVEN a "message" attribute has been applied to the  v-notify elementWHEN the element is renderedTHEN the notify should render the "message" attribute value in the notify message
Variant: default | GIVEN no "variant" attribute has been applied to the v-notify elementOR the "variant" attribute value is not "error", "warning", "success", or "info"WHEN the element is renderedTHEN the notify should render with a blue borderAND the notify should render with a blue info icon
Variant: error | GIVEN a "variant" attribute has been applied to the v-notify elementAND the "variant" attribute value is "error"WHEN the element is renderedTHEN the notify should render with a red borderAND the notify should render with a red error icon
Variant: warning | GIVEN a "variant" attribute has been applied to the v-notify elementAND the "variant" attribute value is "warning"WHEN the element is renderedTHEN the notify should render with an orange borderAND the notify should render with an orange warning  icon
Variant: success | GIVEN a "variant" attribute has been applied to the v-notify elementAND the "variant" attribute value is "success"WHEN the element is renderedTHEN the notify should render with a green borderAND the notify should render with a green check icon
Variant: info | GIVEN a "variant" attribute has been applied to the v-notify elementAND the "variant" attribute value is "info"WHEN the element is renderedTHEN the notify should render with a blue borderAND the notify should render with a blue info icon
Background: default | GIVEN no "background" attribute has been applied to  the v-notify elementOR the "background" attribute value is not "gray" or  "white"WHEN the element is renderedTHEN the notify should render with a gray background
Background: gray | GIVEN a "background" attribute has been applied to the v-notify elementAND the "background" attribute value is "gray"WHEN the element is renderedTHEN the notify should render with a gray background
Background: white | GIVEN a "background" attribute has been applied to the v-notify elementAND the "background" attribute value is "white"WHEN the element is renderedTHEN the notify should render with a white background
Slot | GIVEN a child element in included with the v-notifyWHEN the element is renderedTHEN the notify should render the child element after  the message

