### PR TITLE
App 1341: Don't break the select component when adding special chars to the input

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -26,7 +26,7 @@ setTimeout(() => {
 
 let leftOptions = $ref("one,two,three,ten")
 let rightOptions = $ref("four,five,six,eight,nine")
-
+let selectInput = $ref("")
 </script>
 
 <template>
@@ -123,7 +123,16 @@ let rightOptions = $ref("four,five,six,eight,nine")
       buttonicon="x"
       heading="heading title"
     />
+    <section>
+      <v-select
+      options="test1, test2, test3, test3[]"
+      v-model="selectInput"
+      label="Test Select"
+      state="'info'"
+      class="my-6"
+    />  
 
+    </section>
     <v-collapse class="p-3" title='Hello world?'>
       Hello world
     </v-collapse>

--- a/src/elements/select/utils.ts
+++ b/src/elements/select/utils.ts
@@ -1,3 +1,5 @@
+import { addSpecialCharacterEscapes } from '../../lib/sort';
+
 interface Match { 
   search: string[],
   option: string,
@@ -24,8 +26,10 @@ export const applySearchHighlight = (options: string[], value: string) => {
   const matches = [];
   const noMatches = [];
 
+  const valueCopy = addSpecialCharacterEscapes(value);
+
   for (const option of options) {
-    const match = option.match(new RegExp(value, 'i'));
+    const match = option.match(new RegExp(valueCopy, 'i'));
 
     if (match?.index === undefined) {
       noMatches.push({
@@ -34,8 +38,8 @@ export const applySearchHighlight = (options: string[], value: string) => {
       });
     } else {
       const begin = option.slice(0, match.index);
-      const middle = option.slice(match.index, match.index + value.length);
-      const end = option.slice(match.index + value.length);
+      const middle = option.slice(match.index, match.index + valueCopy.length);
+      const end = option.slice(match.index + valueCopy.length);
       matches.push({
         search: [begin, middle, end],
         option,

--- a/src/lib/sort.ts
+++ b/src/lib/sort.ts
@@ -1,9 +1,21 @@
 /* eslint-disable unicorn/prefer-regexp-test */
+export const addSpecialCharacterEscapes = (value: string) => {
+  // This function takes a value and adds backslashes for special chars 
+  // so that it doesn't treat it as a special character in a
+  let newValue = '';
+
+  for (const element of value) {
+    newValue += /[^\dA-Za-z]/.test(element) ? `\\${element}` : element;
+  }
+  return newValue
+};
+
 export const searchSort = (data: string[], searchTerm: string, reduce: boolean) => {
   const results: Record<string, string[]> = {};
+  const termCopy = addSpecialCharacterEscapes(searchTerm);
 
-  const initialCharacterMatch = new RegExp(`^${searchTerm}`, 'i');
-  const anyMatch = new RegExp(searchTerm, 'gi');
+  const initialCharacterMatch = new RegExp(`^${termCopy}`, 'i');
+  const anyMatch = new RegExp(termCopy, 'gi');
 
   for (const datum of data) {
     let index = -1;


### PR DESCRIPTION
The bug was that when we add special characters to the v-select, we convert the string to a regex. This means if there are special characters in the string, it will break the component, and ultimately the page. This adds backslashes to any special character in the string, and will treat that as a character to match on rahter than a special character. 