### PR TITLE
App 1352: Adding component tests for monaco-editor

### DIFF
--- a/playground/code-editor-test.html
+++ b/playground/code-editor-test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>PRIME Testbed: Code Editor</title>
+
+    <script type="module">
+      window.PRIME_CONFIG = { base: '' }
+    </script>
+
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="./src/code-editor-test.ts"></script>
+  </body>
+</html>

--- a/playground/src/code-editor-test.ts
+++ b/playground/src/code-editor-test.ts
@@ -1,0 +1,6 @@
+import './main.css'
+import '../../src/main'
+import { createApp } from 'vue'
+import App from './code-editor-test.vue'
+
+createApp(App).mount('#app')

--- a/playground/src/code-editor-test.vue
+++ b/playground/src/code-editor-test.vue
@@ -1,6 +1,58 @@
 <script setup lang="ts">
-const javascriptString = "function getComponents(){" + "\n\n" + "}"
-const typescriptString = "function get(value: string) {" + "\n\n" + "}"
+import { json } from 'body-parser';
+import { diff } from 'semver';
+
+const javascriptString = `function getComponents(){
+
+}`
+const typescriptString = `function get(value: string) {
+
+}`
+
+const minimapString = `{
+    "test": [], 
+    "test1": [], 
+    "test2": [], 
+    "test3": [], 
+    "test4": [], 
+    "test5": []
+}
+`
+
+const diffString = `{
+    "test": [], 
+    "test1": [], 
+    "test2": [], 
+    "test3": [], 
+    "test4": [], 
+}
+`
+
+
+const schema = JSON.stringify({
+  $schema: 'http://json-schema.org/draft-04/schema#',
+  $ref: '#/definitions/AttrConfig',
+  definitions: {
+    AttrConfig: {
+      required: ['token', 'host'],
+      properties: {
+        hello: {
+            type: 'integer', 
+            description: 'integer'
+        }
+      },
+      additionalProperties: false,
+      type: 'object',
+    },
+  },
+});
+
+const basicJson = `
+{
+  "hello": "world"
+}
+`
+
 </script>
 
 <template>
@@ -59,6 +111,83 @@ const typescriptString = "function get(value: string) {" + "\n\n" + "}"
           data-testid='code-editor-python-invalid'
           value="const x = () => {}"
           language='python'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-golang-valid'
+          value="func (s *Custom) help(x int)"
+          language='go'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-golang-invalid'
+          value="def help(x int)"
+          language='go'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-shell-valid'
+          value="echo test"
+          language='shell'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-shell-invalid'
+          value="help me!!"
+          language='shell'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-vs'
+          value='{"component": "JSON"}'
+          language='json'
+          theme="vs"
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-readonly'
+          value='{"component": "readonly"}'
+          language='json'
+          readonly="true"
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-minimap'
+          :value="minimapString"
+          language='json'
+          minimap="true"
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-diff'
+          :value="minimapString"
+          :previous="diffString"
+          variant="diff"
+          language="json"
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-schema'
+          :value="basicJson"
+          :schema="schema"
+          language="json"
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-vs-dark'
+          value='{"component": "JSON"}'
+          language='json'
+          theme="vs-dark"
         />
       </div>
   </main>

--- a/playground/src/code-editor-test.vue
+++ b/playground/src/code-editor-test.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+const javascriptString = "function getComponents(){" + "\n\n" + "}"
+const typescriptString = "function get(value: string) {" + "\n\n" + "}"
+</script>
+
+<template>
+  <main>
+    <div style='width: 400px; height: 200px;'>
+      <v-code-editor
+        data-testid='code-editor-json-valid'
+        value='{"component": "JSON"}'
+        language='json'
+      />
+    </div>
+    <div style='width: 400px; height: 200px;'>
+      <v-code-editor
+        data-testid='code-editor-json-invalid'
+        value='{"component"}'
+        language='json'
+      />
+    </div>
+    <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-javascript-valid'
+          :value="javascriptString"
+          language='javascript'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-javascript-invalid'
+          value="def madeIt()"
+          language='javascript'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-typescript-valid'
+          :value="typescriptString"
+          language='typescript'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-typescript-invalid'
+          value="def help()"
+          language='typescript'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-python-valid'
+          value="def help()"
+          language='python'
+        />
+      </div>
+      <div style='width: 400px; height: 200px;'>
+        <v-code-editor
+          data-testid='code-editor-python-invalid'
+          value="const x = () => {}"
+          language='python'
+        />
+      </div>
+  </main>
+</template>

--- a/src/elements/code-editor.svelte
+++ b/src/elements/code-editor.svelte
@@ -72,7 +72,6 @@ const setModel = () => {
     const id = String(hashCode(schema));
     const uri = `http://${id}.json/`;
     const modelUri = window.monaco.Uri.parse(uri);
-
     monacoUtils.removeSchemas(id, parsedSchema);
     monacoUtils.addSchemas(id, parsedSchema, [modelUri.toString()]);
     model = window.monaco.editor.createModel(value, language, modelUri);

--- a/src/elements/code-editor.svelte
+++ b/src/elements/code-editor.svelte
@@ -78,7 +78,7 @@ const setModel = () => {
   } else {
     model = window.monaco.editor.createModel(value, language);
   }
-
+  
   dispatch('update-model', { model });
   editor.setModel(model);
 };

--- a/src/lib/monaco/index.ts
+++ b/src/lib/monaco/index.ts
@@ -45,7 +45,6 @@ const updateRefs = (id: string, definition: SubSchema): Record<string, string> =
 
 const addSchemas = (id: string, schema: Schema, fileMatch: string[]) => {
   const { $ref, definitions = {} } = schema;
-
   for (const [key, definition] of Object.entries(definitions)) {
     schemas.push({
       uri: makeRefUri(id, key),
@@ -54,7 +53,6 @@ const addSchemas = (id: string, schema: Schema, fileMatch: string[]) => {
       ...(keyFromRef($ref) === key ? { fileMatch } : undefined),
     });
   }
-
   window.monaco.languages.json.jsonDefaults.setDiagnosticsOptions({
     validate: true,
     schemas,

--- a/tests/code-editor.spec.ts
+++ b/tests/code-editor.spec.ts
@@ -1,194 +1,156 @@
 import { test, expect } from '@playwright/test';
 
+test.beforeEach(async ({page}) => {
+    await page.goto('/code-editor-test.html')
+})
+
 test('Renders JSON code editor correctly', async ({ page }) => {
-  await page.goto('/code-editor-test.html');
   const validJSONEditor = page.getByTestId('code-editor-json-valid')
-  await expect(validJSONEditor).toHaveCount(1)
   await expect(validJSONEditor).toHaveAttribute('language', 'json')
   await expect(validJSONEditor).toHaveAttribute('value', '{"component": "JSON"}')
   const monacoContainer = validJSONEditor.locator('div').first()
-  await expect(monacoContainer).toHaveCount(1);
   await expect(monacoContainer).toHaveAttribute('data-mode-id', 'json')
-
-  // TODO: Add language syntax -- should we be checking that the keys and the values are in the 
+  const componentSpan = monacoContainer.getByText('component') // refers to key
+  await expect(componentSpan).toHaveClass(/mtk4/)
+  const jsonSPAN = monacoContainer.getByText('JSON')
+  await expect(jsonSPAN).toHaveClass(/mtk5/)
 });
 
 // Value: JSON invalid
 
 test('Renders JSON code editor that is invalid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const validJSONEditor = page.getByTestId('code-editor-json-invalid')
-    await expect(validJSONEditor).toHaveCount(1)
     await expect(validJSONEditor).toHaveAttribute('language', 'json')
     await expect(validJSONEditor).toHaveAttribute('value', '{"component"}')
     const monacoContainer = validJSONEditor.locator('div').first()
-    await expect(monacoContainer).toHaveCount(1);
     await expect(monacoContainer).toHaveAttribute('data-mode-id', 'json')
 });
 
 // valid javascript
 
 test('Renders Javascript code editor that is valid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const validJavascriptEditor = page.getByTestId('code-editor-javascript-valid')
-    await expect(validJavascriptEditor).toHaveCount(1)
     await expect(validJavascriptEditor).toHaveAttribute('language', 'javascript')
     await expect(validJavascriptEditor).toHaveAttribute('value', "function getComponents(){" + "\n\n" + "}")
     const validJSONContainer = validJavascriptEditor.locator('div').first()
-    await expect(validJSONContainer).toHaveCount(1); 
     await expect(validJSONContainer).toHaveAttribute('data-mode-id', 'javascript')
+    await expect(validJSONContainer.getByText('function')).toHaveClass(/mtk8/) // valid
 })
 
 // invalid javascript
 
 test('Renders Javascript code editor that is invalid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const invalidJavascriptEditor = page.getByTestId('code-editor-javascript-invalid')
-    await expect(invalidJavascriptEditor).toHaveCount(1)
     await expect(invalidJavascriptEditor).toHaveAttribute('language', 'javascript')
     await expect(invalidJavascriptEditor).toHaveAttribute('value', "def madeIt()")
     const invalidEditor = invalidJavascriptEditor.locator('div').first()
-    await expect(invalidEditor).toHaveCount(1)
     await expect(invalidEditor).toHaveAttribute('data-mode-id', 'javascript')
 })
 
 // valid typescript
 
 test('Renders typescript code editor that is valid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const validTypescriptEditor = page.getByTestId('code-editor-typescript-valid')
-    await expect(validTypescriptEditor).toHaveCount(1)
     await expect(validTypescriptEditor).toHaveAttribute('language', 'typescript')
     await expect(validTypescriptEditor).toHaveAttribute('value', "function get(value: string) {" + "\n\n" + "}")
     const validEditor = validTypescriptEditor.locator('div').first()
-    await expect(validEditor).toHaveCount(1)
     await expect(validEditor).toHaveAttribute('data-mode-id', 'typescript')
+    await expect(validTypescriptEditor.getByText('function')).toHaveClass(/mtk8/) // valid
 })
 
 // invalid typescript
 test('Renders typescript code editor that is invalid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const invalidTypescriptEditor = page.getByTestId('code-editor-typescript-invalid')
-    await expect(invalidTypescriptEditor).toHaveCount(1)
     await expect(invalidTypescriptEditor).toHaveAttribute('language', 'typescript')
     await expect(invalidTypescriptEditor).toHaveAttribute('value', "def help()")
     const invalidEditor = invalidTypescriptEditor.locator('div').first()
-    await expect(invalidEditor).toHaveCount(1)
     await expect(invalidEditor).toHaveAttribute('data-mode-id','typescript')
+    await expect(invalidEditor.getByText('def help')).toHaveClass(/mtk1/)
 })
 
 // valid python 
 test('Renders python editor that is valid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const validPythonEditor = page.getByTestId('code-editor-python-valid')
-    await expect(validPythonEditor).toHaveCount(1)
     await expect(validPythonEditor).toHaveAttribute('language', 'python')
     await expect(validPythonEditor).toHaveAttribute('value', "def help()")
     const validEditor = validPythonEditor.locator('div').first()
-    await expect(validEditor).toHaveCount(1)
     await expect(validEditor).toHaveAttribute('data-mode-id', 'python')
+    await expect(validEditor.getByText('def')).toHaveClass(/mtk8/) // valid python syntax
+    await expect(validEditor.getByText('help')).toHaveClass(/mtk8/)
 })
 
 // invalid python 
 test('Renders python editor that is invalid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const invalidPythonEditor = page.getByTestId('code-editor-python-invalid')
-    await expect(invalidPythonEditor).toHaveCount(1)
     await expect(invalidPythonEditor).toHaveAttribute('language', 'python')
     await expect(invalidPythonEditor).toHaveAttribute('value', "const x = () => {}")
     const invalidEditor = invalidPythonEditor.locator('div').first()
-    await expect(invalidEditor).toHaveCount(1)
     await expect(invalidEditor).toHaveAttribute('data-mode-id', 'python')
 })
 
 test('Renders a golang editor that is valid', async ({page}) => {
-    await page.goto('/code-editor-test.html');
     const editor = page.getByTestId('code-editor-golang-valid')
-    await expect(editor).toHaveCount(1)
     await expect(editor).toHaveAttribute('language', 'go')
     await expect(editor).toHaveAttribute('value', "func (s *Custom) help(x int)")
     const editorContainer = editor.locator('div').first()
-    await expect(editorContainer).toHaveCount(1)
     await expect(editorContainer).toHaveAttribute('data-mode-id', 'go')
+    await expect(editorContainer.getByText('func')).toHaveClass(/mtk8/) // valid 
 })
 
 test('Renders a golang editor that is invalid', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-golang-invalid')
-    await expect(editor).toHaveCount(1)
     await expect(editor).toHaveAttribute('language', 'go')
     await expect(editor).toHaveAttribute('value', "def help(x int)")
     const editorContainer = editor.locator('div').first()
-    await expect(editorContainer).toHaveCount(1)
     await expect(editorContainer).toHaveAttribute('data-mode-id', 'go')
 })
 
 test('Renders a shell editor that is valid', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-shell-valid')
-    await expect(editor).toHaveCount(1)
     await expect(editor).toHaveAttribute('language', 'shell')
     await expect(editor).toHaveAttribute('value', "echo test")
     const editorContainer = editor.locator('div').first()
-    await expect(editorContainer).toHaveCount(1)
     await expect(editorContainer).toHaveAttribute('data-mode-id', 'shell')
+    await expect(editorContainer.getByText('echo')).toHaveClass(/mtk22/) // valid for shell
 })
 
 test('Renders a shell editor that is invalid', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-shell-invalid')
-    await expect(editor).toHaveCount(1)
     await expect(editor).toHaveAttribute('language', 'shell')
     await expect(editor).toHaveAttribute('value', "help me!!")
     const editorContainer = editor.locator('div').first()
-    await expect(editorContainer).toHaveCount(1)
     await expect(editorContainer).toHaveAttribute('data-mode-id', 'shell')
 })
 
 test('Renders the default vs-code theme if none is provided', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-json-valid')
-    await expect(editor).toHaveCount(1)
     const monacoEditor = editor.locator('.monaco-editor').first()
-    await expect(monacoEditor).toHaveCount(1)
     await expect(monacoEditor).toHaveClass(/vs/)
 })
 
 test('Renders the vs theme if set on the vs-code-editor element', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-vs')
-    await expect(editor).toHaveCount(1)
     const monacoEditor = editor.locator('.monaco-editor').first()
-    await expect(monacoEditor).toHaveCount(1)
     await expect(monacoEditor).toHaveClass(/vs/)
 })
 
 test('Renders the vs-dark theme if set on the vs-code-editor element', async ({page}) => {
-    // TODO: Fix the issue if there are many editors in a row then it makes all of them vs dark
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-vs-dark')
-    await expect(editor).toHaveCount(1)
     const monacoEditor = editor.locator('.monaco-editor').first()
-    await expect(monacoEditor).toHaveCount(1)
     await expect(monacoEditor).toHaveClass(/vs-dark/)
 })
 
 test('If a readonly attribute is not set, the editor should be editable', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const validJSONEditor = page.getByTestId('code-editor-json-valid')
     const originalString = '{"component": "JSON"}'
-
-    await expect(validJSONEditor).toHaveCount(1)
-
     const textarea = validJSONEditor.locator('textarea')
-    await expect(textarea).toHaveCount(1)
 
     // clears the input -- this was the only way to do it without hanging
     for (let i = 0; i < originalString.length; i++) {
         await textarea.clear()
     }
     await textarea.fill('{"remote": "test"}')
-    await expect(validJSONEditor.locator('.message', {hasText: 'Cannot edit in read-only editor'})).toHaveCount(0)
+    await expect(validJSONEditor.locator('.message', {hasText: 'Cannot edit in read-only editor'})).not.toBeVisible()
 
     expect(await textarea.inputValue()).toEqual('{"remote": "test"}')
     // check that the value in the div has the new string
@@ -197,15 +159,12 @@ test('If a readonly attribute is not set, the editor should be editable', async 
 })
 
 test('If a readonly attribute is set, then the editor should be not editable', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-readonly')
-    await expect(editor).toHaveCount(1)
     // get the textarea input
     const textarea = editor.locator('textarea')
-    await expect(textarea).toHaveCount(1)
 
     await textarea.type('hello')
-    await expect(editor.locator('.message', {hasText: 'Cannot edit in read-only editor'})).toHaveCount(1)
+    await expect(editor.locator('.message', {hasText: 'Cannot edit in read-only editor'})).toBeVisible()
 
     // expect the text on the editor to not actually change
     await textarea.fill('hello')
@@ -214,28 +173,22 @@ test('If a readonly attribute is set, then the editor should be not editable', a
 })
 
 test('Render a minimap if the minimap attribute is set to true', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-minimap')
-    await expect(editor).toHaveCount(1)
     const width = parseInt(await editor.locator('.minimap-decorations-layer').getAttribute('width') ?? '0')
     expect(width).toBeGreaterThan(0)
 })
 
 test('If a minimap attribute is not set, the it should not render one', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-json-valid')
-    await expect(editor).toHaveCount(1)
     const width = parseInt(await editor.locator('.minimap-decorations-layer').getAttribute('width') ?? '0')
     expect(width).toEqual(0)
 })
 
 test('Render a diff code editor if there is a previous attribute and variant diff', async ({page}) => {
-    await page.goto('/code-editor-test.html')
     const editor = page.getByTestId('code-editor-diff')
-    await expect(editor).toHaveCount(1)
     const diffEditor = editor.locator('.monaco-diff-editor')
     await expect(diffEditor).toHaveClass(/side-by-side/)
-    await expect(diffEditor).toHaveCount(1)
+    await expect(diffEditor).toBeVisible()
 
     // default renders in JSON
     await expect(editor.locator('.editor.original')).toHaveAttribute('data-mode-id', 'json')

--- a/tests/code-editor.spec.ts
+++ b/tests/code-editor.spec.ts
@@ -1,11 +1,5 @@
 import { test, expect } from '@playwright/test';
 
-// Value: JSON
-
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "json" has been applied to the v-code-editor-element
-// WHEN the element is rendered
-// THEN the code editor should render the "value" attribute value in the code-editor with JSON language syntax highlighting
-
 test('Renders JSON code editor correctly', async ({ page }) => {
   await page.goto('/code-editor-test.html');
   const validJSONEditor = page.getByTestId('code-editor-json-valid')
@@ -17,7 +11,6 @@ test('Renders JSON code editor correctly', async ({ page }) => {
   await expect(monacoContainer).toHaveAttribute('data-mode-id', 'json')
 
   // TODO: Add language syntax -- should we be checking that the keys and the values are in the 
-
 });
 
 // Value: JSON invalid
@@ -108,74 +101,148 @@ test('Renders python editor that is invalid', async ({page}) => {
     await expect(invalidEditor).toHaveAttribute('data-mode-id', 'python')
 })
 
-// Value: JavaScript invalid
+test('Renders a golang editor that is valid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const editor = page.getByTestId('code-editor-golang-valid')
+    await expect(editor).toHaveCount(1)
+    await expect(editor).toHaveAttribute('language', 'go')
+    await expect(editor).toHaveAttribute('value', "func (s *Custom) help(x int)")
+    const editorContainer = editor.locator('div').first()
+    await expect(editorContainer).toHaveCount(1)
+    await expect(editorContainer).toHaveAttribute('data-mode-id', 'go')
+})
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "javascript" has been applied to the v-code-editor-elementAND the "value" attribute is invalid JavaScriptWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with JavaScript language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+test('Renders a golang editor that is invalid', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-golang-invalid')
+    await expect(editor).toHaveCount(1)
+    await expect(editor).toHaveAttribute('language', 'go')
+    await expect(editor).toHaveAttribute('value', "def help(x int)")
+    const editorContainer = editor.locator('div').first()
+    await expect(editorContainer).toHaveCount(1)
+    await expect(editorContainer).toHaveAttribute('data-mode-id', 'go')
+})
 
-// Value: TypeScript
+test('Renders a shell editor that is valid', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-shell-valid')
+    await expect(editor).toHaveCount(1)
+    await expect(editor).toHaveAttribute('language', 'shell')
+    await expect(editor).toHaveAttribute('value', "echo test")
+    const editorContainer = editor.locator('div').first()
+    await expect(editorContainer).toHaveCount(1)
+    await expect(editorContainer).toHaveAttribute('data-mode-id', 'shell')
+})
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "typescript" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with TypeScript language syntax highlighting
+test('Renders a shell editor that is invalid', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-shell-invalid')
+    await expect(editor).toHaveCount(1)
+    await expect(editor).toHaveAttribute('language', 'shell')
+    await expect(editor).toHaveAttribute('value', "help me!!")
+    const editorContainer = editor.locator('div').first()
+    await expect(editorContainer).toHaveCount(1)
+    await expect(editorContainer).toHaveAttribute('data-mode-id', 'shell')
+})
 
-// Value: TypeScript invalid
+test('Renders the default vs-code theme if none is provided', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-json-valid')
+    await expect(editor).toHaveCount(1)
+    const monacoEditor = editor.locator('.monaco-editor').first()
+    await expect(monacoEditor).toHaveCount(1)
+    await expect(monacoEditor).toHaveClass(/vs/)
+})
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "typescript" has been applied to the v-code-editor-elementAND the "value" attribute is invalid TypeScriptWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with TypeScript language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+test('Renders the vs theme if set on the vs-code-editor element', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-vs')
+    await expect(editor).toHaveCount(1)
+    const monacoEditor = editor.locator('.monaco-editor').first()
+    await expect(monacoEditor).toHaveCount(1)
+    await expect(monacoEditor).toHaveClass(/vs/)
+})
 
-// Value: Python
+test('Renders the vs-dark theme if set on the vs-code-editor element', async ({page}) => {
+    // TODO: Fix the issue if there are many editors in a row then it makes all of them vs dark
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-vs-dark')
+    await expect(editor).toHaveCount(1)
+    const monacoEditor = editor.locator('.monaco-editor').first()
+    await expect(monacoEditor).toHaveCount(1)
+    await expect(monacoEditor).toHaveClass(/vs-dark/)
+})
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "python" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Python language syntax highlighting
+test('If a readonly attribute is not set, the editor should be editable', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const validJSONEditor = page.getByTestId('code-editor-json-valid')
+    const originalString = '{"component": "JSON"}'
 
-// Value: Python invalid
+    await expect(validJSONEditor).toHaveCount(1)
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "python" has been applied to the v-code-editor-elementAND the "value" attribute is invalid PythonWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Python language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+    const textarea = validJSONEditor.locator('textarea')
+    await expect(textarea).toHaveCount(1)
 
-// Value: Go
+    // clears the input -- this was the only way to do it without hanging
+    for (let i = 0; i < originalString.length; i++) {
+        await textarea.clear()
+    }
+    await textarea.fill('{"remote": "test"}')
+    await expect(validJSONEditor.locator('.message', {hasText: 'Cannot edit in read-only editor'})).toHaveCount(0)
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "go" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Go language syntax highlighting
+    expect(await textarea.inputValue()).toEqual('{"remote": "test"}')
+    // check that the value in the div has the new string
+    await expect(validJSONEditor).toContainText('{"remote": "test"}')
+    await expect(validJSONEditor).not.toContainText(originalString)
+})
 
-// Value: Go invalid
+test('If a readonly attribute is set, then the editor should be not editable', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-readonly')
+    await expect(editor).toHaveCount(1)
+    // get the textarea input
+    const textarea = editor.locator('textarea')
+    await expect(textarea).toHaveCount(1)
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "go" has been applied to the v-code-editor-elementAND the "value" attribute is invalid GoWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Go language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+    await textarea.type('hello')
+    await expect(editor.locator('.message', {hasText: 'Cannot edit in read-only editor'})).toHaveCount(1)
 
-// Value: Shell
+    // expect the text on the editor to not actually change
+    await textarea.fill('hello')
+    await expect(editor).not.toContainText(/hello/)
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "shell" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Shell language syntax highlighting
+})
 
-// Value: Shell invalid
+test('Render a minimap if the minimap attribute is set to true', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-minimap')
+    await expect(editor).toHaveCount(1)
+    const width = parseInt(await editor.locator('.minimap-decorations-layer').getAttribute('width') ?? '0')
+    expect(width).toBeGreaterThan(0)
+})
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "shell" has been applied to the v-code-editor-elementAND the "value" attribute is invalid ShellWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Shell language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+test('If a minimap attribute is not set, the it should not render one', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-json-valid')
+    await expect(editor).toHaveCount(1)
+    const width = parseInt(await editor.locator('.minimap-decorations-layer').getAttribute('width') ?? '0')
+    expect(width).toEqual(0)
+})
 
-// Value: invalid language
+test('Render a diff code editor if there is a previous attribute and variant diff', async ({page}) => {
+    await page.goto('/code-editor-test.html')
+    const editor = page.getByTestId('code-editor-diff')
+    await expect(editor).toHaveCount(1)
+    const diffEditor = editor.locator('.monaco-diff-editor')
+    await expect(diffEditor).toHaveClass(/side-by-side/)
+    await expect(diffEditor).toHaveCount(1)
 
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute has been applied to the v-code-editor-element with an invalid language typeWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with no language syntax highlighting
+    // default renders in JSON
+    await expect(editor.locator('.editor.original')).toHaveAttribute('data-mode-id', 'json')
+    await expect(editor.locator('.editor.modified')).toHaveAttribute('data-mode-id', 'json')
 
-// Theme: default
+    // modified should have the "current state" -- the difference is an extra row so just check for that
+    await expect(editor.locator('.editor.modified')).toContainText('test5')
+    await expect(editor.locator('.editor.original')).not.toContainText('test5')
 
-// GIVEN no "theme" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render with the default "vs" theme
-
-// Theme: vs
-
-// GIVEN a "theme" attribute of "vs" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render with the "vs" theme
-
-// Theme: vs-dark
-
-// GIVEN a "theme" attribute of "vs-dark" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render with the "vs-dark" theme
-
-// Readonly
-
-// GIVEN a "readonly" attribute of "true" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the editor value should not be editableAND a info tooltip should render when attempting to edit the value
-
-// Mini Map
-
-// GIVEN a "minimap" attribute of "true" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render a "mini map" of the value on the right side of the editor
-
-// Schema
-
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "json" has been applied to the v-code-editor-elementAND a "schema" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should use the custom schema for validation
-
-// Variant: default
-
-// GIVEN no "variant" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render as a standard editor
-
-// Variant: diff
-
-// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "variant" attribute of "diff" has been applied to the v-code-editor elementAND a "previous" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render as a diff editorAND differences between the "value" and "previous" values should be highlighted
+})

--- a/tests/code-editor.spec.ts
+++ b/tests/code-editor.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect } from '@playwright/test';
+
+// Value: JSON
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "json" has been applied to the v-code-editor-element
+// WHEN the element is rendered
+// THEN the code editor should render the "value" attribute value in the code-editor with JSON language syntax highlighting
+
+test('Renders JSON code editor correctly', async ({ page }) => {
+  await page.goto('/code-editor-test.html');
+  const validJSONEditor = page.getByTestId('code-editor-json-valid')
+  await expect(validJSONEditor).toHaveCount(1)
+  await expect(validJSONEditor).toHaveAttribute('language', 'json')
+  await expect(validJSONEditor).toHaveAttribute('value', '{"component": "JSON"}')
+  const monacoContainer = validJSONEditor.locator('div').first()
+  await expect(monacoContainer).toHaveCount(1);
+  await expect(monacoContainer).toHaveAttribute('data-mode-id', 'json')
+
+  // TODO: Add language syntax -- should we be checking that the keys and the values are in the 
+
+});
+
+// Value: JSON invalid
+
+test('Renders JSON code editor that is invalid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const validJSONEditor = page.getByTestId('code-editor-json-invalid')
+    await expect(validJSONEditor).toHaveCount(1)
+    await expect(validJSONEditor).toHaveAttribute('language', 'json')
+    await expect(validJSONEditor).toHaveAttribute('value', '{"component"}')
+    const monacoContainer = validJSONEditor.locator('div').first()
+    await expect(monacoContainer).toHaveCount(1);
+    await expect(monacoContainer).toHaveAttribute('data-mode-id', 'json')
+});
+
+// valid javascript
+
+test('Renders Javascript code editor that is valid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const validJavascriptEditor = page.getByTestId('code-editor-javascript-valid')
+    await expect(validJavascriptEditor).toHaveCount(1)
+    await expect(validJavascriptEditor).toHaveAttribute('language', 'javascript')
+    await expect(validJavascriptEditor).toHaveAttribute('value', "function getComponents(){" + "\n\n" + "}")
+    const validJSONContainer = validJavascriptEditor.locator('div').first()
+    await expect(validJSONContainer).toHaveCount(1); 
+    await expect(validJSONContainer).toHaveAttribute('data-mode-id', 'javascript')
+})
+
+// invalid javascript
+
+test('Renders Javascript code editor that is invalid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const invalidJavascriptEditor = page.getByTestId('code-editor-javascript-invalid')
+    await expect(invalidJavascriptEditor).toHaveCount(1)
+    await expect(invalidJavascriptEditor).toHaveAttribute('language', 'javascript')
+    await expect(invalidJavascriptEditor).toHaveAttribute('value', "def madeIt()")
+    const invalidEditor = invalidJavascriptEditor.locator('div').first()
+    await expect(invalidEditor).toHaveCount(1)
+    await expect(invalidEditor).toHaveAttribute('data-mode-id', 'javascript')
+})
+
+// valid typescript
+
+test('Renders typescript code editor that is valid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const validTypescriptEditor = page.getByTestId('code-editor-typescript-valid')
+    await expect(validTypescriptEditor).toHaveCount(1)
+    await expect(validTypescriptEditor).toHaveAttribute('language', 'typescript')
+    await expect(validTypescriptEditor).toHaveAttribute('value', "function get(value: string) {" + "\n\n" + "}")
+    const validEditor = validTypescriptEditor.locator('div').first()
+    await expect(validEditor).toHaveCount(1)
+    await expect(validEditor).toHaveAttribute('data-mode-id', 'typescript')
+})
+
+// invalid typescript
+test('Renders typescript code editor that is invalid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const invalidTypescriptEditor = page.getByTestId('code-editor-typescript-invalid')
+    await expect(invalidTypescriptEditor).toHaveCount(1)
+    await expect(invalidTypescriptEditor).toHaveAttribute('language', 'typescript')
+    await expect(invalidTypescriptEditor).toHaveAttribute('value', "def help()")
+    const invalidEditor = invalidTypescriptEditor.locator('div').first()
+    await expect(invalidEditor).toHaveCount(1)
+    await expect(invalidEditor).toHaveAttribute('data-mode-id','typescript')
+})
+
+// valid python 
+test('Renders python editor that is valid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const validPythonEditor = page.getByTestId('code-editor-python-valid')
+    await expect(validPythonEditor).toHaveCount(1)
+    await expect(validPythonEditor).toHaveAttribute('language', 'python')
+    await expect(validPythonEditor).toHaveAttribute('value', "def help()")
+    const validEditor = validPythonEditor.locator('div').first()
+    await expect(validEditor).toHaveCount(1)
+    await expect(validEditor).toHaveAttribute('data-mode-id', 'python')
+})
+
+// invalid python 
+test('Renders python editor that is invalid', async ({page}) => {
+    await page.goto('/code-editor-test.html');
+    const invalidPythonEditor = page.getByTestId('code-editor-python-invalid')
+    await expect(invalidPythonEditor).toHaveCount(1)
+    await expect(invalidPythonEditor).toHaveAttribute('language', 'python')
+    await expect(invalidPythonEditor).toHaveAttribute('value', "const x = () => {}")
+    const invalidEditor = invalidPythonEditor.locator('div').first()
+    await expect(invalidEditor).toHaveCount(1)
+    await expect(invalidEditor).toHaveAttribute('data-mode-id', 'python')
+})
+
+// Value: JavaScript invalid
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "javascript" has been applied to the v-code-editor-elementAND the "value" attribute is invalid JavaScriptWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with JavaScript language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+
+// Value: TypeScript
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "typescript" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with TypeScript language syntax highlighting
+
+// Value: TypeScript invalid
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "typescript" has been applied to the v-code-editor-elementAND the "value" attribute is invalid TypeScriptWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with TypeScript language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+
+// Value: Python
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "python" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Python language syntax highlighting
+
+// Value: Python invalid
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "python" has been applied to the v-code-editor-elementAND the "value" attribute is invalid PythonWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Python language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+
+// Value: Go
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "go" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Go language syntax highlighting
+
+// Value: Go invalid
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "go" has been applied to the v-code-editor-elementAND the "value" attribute is invalid GoWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Go language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+
+// Value: Shell
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "shell" has been applied to the v-code-editor-elementWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Shell language syntax highlighting
+
+// Value: Shell invalid
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "shell" has been applied to the v-code-editor-elementAND the "value" attribute is invalid ShellWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with Shell language syntax highlightingAND the invalid portion of the "value" attribute value should be highlighted as an error
+
+// Value: invalid language
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute has been applied to the v-code-editor-element with an invalid language typeWHEN the element is renderedTHEN the code editor should render the "value" attribute value in the code-editor with no language syntax highlighting
+
+// Theme: default
+
+// GIVEN no "theme" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render with the default "vs" theme
+
+// Theme: vs
+
+// GIVEN a "theme" attribute of "vs" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render with the "vs" theme
+
+// Theme: vs-dark
+
+// GIVEN a "theme" attribute of "vs-dark" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render with the "vs-dark" theme
+
+// Readonly
+
+// GIVEN a "readonly" attribute of "true" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the editor value should not be editableAND a info tooltip should render when attempting to edit the value
+
+// Mini Map
+
+// GIVEN a "minimap" attribute of "true" has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render a "mini map" of the value on the right side of the editor
+
+// Schema
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "language" attribute of "json" has been applied to the v-code-editor-elementAND a "schema" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should use the custom schema for validation
+
+// Variant: default
+
+// GIVEN no "variant" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render as a standard editor
+
+// Variant: diff
+
+// GIVEN a "value" attribute has been applied to the v-code-editor elementAND a "variant" attribute of "diff" has been applied to the v-code-editor elementAND a "previous" attribute has been applied to the v-code-editor elementWHEN the element is renderedTHEN the code editor should render as a diff editorAND differences between the "value" and "previous" values should be highlighted

--- a/tests/select.spec.ts
+++ b/tests/select.spec.ts
@@ -17,4 +17,5 @@ test('user is able to make a selection with mouse', async ({ page }) => {
   option.click()
 
   await expect(input).toHaveValue(/sticky bogs/i)
+
 });


### PR DESCRIPTION
I had some issues making tests for the monaco editor because monaco does a lot of things under the hood which are hard to determine via CSS.
1. Syntax highlighting - through looking at CSS it's clear that monaco has different styles that it renders for group of text depending on its language & whether its correct syntax. It's unclear what classes match to what combinations for these, so for now I avoided creating tests for syntax highlighting. 
2. Syntax highlighting for incorrect syntax - for the same reason ^ its difficult to know whether the syntax is correct via the css classes for each line in the editor. Looking at the /code-editor-test.html, we can manually inspect whether the syntax is highlighted correctly. I maninly added separate tests for invalid syntax to check that they were still being rendered. 
3. Schema validation - seems to be correctly working, but again hard to determine if the correct things are being highlighted via CSS. 
4. dark-mode -- you cannot have multiple editors with different themes on the same page, so the tests work correctly but if you load /code-editor-test.html, all the editors will be dark. 