### PR TITLE
Increase E2E test timeout in CI

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -27,7 +27,7 @@ jobs:
         run: npm run check
 
   test:
-    timeout-minutes: 10
+    timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## Overview

The CI runs for #205 and #210 are currently (at the time of writing) failing due to cancellation timeouts. This PR increases the timeout, accordingly.

How does doubling the value seem to everyone?

## Test plan

Ensure CI is green.