### PR TITLE
Make titles bold on notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "@floating-ui/dom": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/src/elements/notify.svelte
+++ b/src/elements/notify.svelte
@@ -56,7 +56,7 @@ addStyles();
       {/if}
 
       <figure>
-        <figcaption class="text-sm font-medium text-default">
+        <figcaption class="text-sm font-bold text-default">
           {title}
         </figcaption>
 


### PR DESCRIPTION
Use `font-bold` rather than `font-medium` class to support regular and bold variants rather than regular and medium.