### PR TITLE
design updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@viamrobotics/prime",
-      "version": "0.2.2",
+      "version": "0.2.3",
       "license": "Apache-2.0",
       "devDependencies": {
         "@floating-ui/dom": "^1.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/src/elements/button/button.svelte
+++ b/src/elements/button/button.svelte
@@ -69,8 +69,8 @@ const handleParentClick = (event: PointerEvent) => {
     class={cx('whitespace-nowrap', {
       'h-[30px] w-[30px]': variant === 'icon',
       'px-4': !icon || variant === 'icon',
-      'pl-3 pr-4': icon && variant !== 'icon',
-      'inline-flex items-center justify-center gap-1.5 py-1 text-sm border':
+      'pl-2 pr-3': icon && variant !== 'icon',
+      'inline-flex items-center justify-center gap-1.5 px-3 py-1.5 text-xs border':
         variant !== 'icon',
       'bg-light border-light hover:bg-medium hover:border-medium active:bg-gray-2':
         variant === 'primary',

--- a/src/elements/input/input.svelte
+++ b/src/elements/input/input.svelte
@@ -282,7 +282,7 @@ const handleNumberDragDown = async (event: PointerEvent) => {
     aria-disabled={isDisabled ? true : undefined}
     bind:this={input}
     class={cx(
-      'w-full py-1 pr-2 leading-tight text-sm h-[30px] border outline-none appearance-none',
+      'w-full py-1.5 px-2 leading-tight text-xs h-[30px] border outline-none appearance-none',
       {
         'pl-2.5': isNumeric === false,
         'pl-3': isNumeric,

--- a/src/elements/radio.svelte
+++ b/src/elements/radio.svelte
@@ -67,7 +67,7 @@ const handleClick = (value: string) => {
   <div class="flex flex-nowrap">
     {#each parsedOptions as option}
       <button
-        class={cx('whitespace-nowrap border px-4 py-1 text-sm', {
+        class={cx('whitespace-nowrap border px-3 py-1.5 text-xs', {
           'bg-medium border-light text-subtle-1':
             option !== selected && !isReadonly,
           'bg-light border-gray-6 text-default font-semibold':

--- a/src/elements/select/multiselect.svelte
+++ b/src/elements/select/multiselect.svelte
@@ -300,7 +300,7 @@ $: {
             aria-disabled={isDisabled ? true : undefined}
             type="text"
             class={cx(
-              'py-1 pl-2.5 pr-1 grow text-sm outline-none appearance-none w-full border bg-white',
+              'py-1.5 pl-2 pr-1 grow text-xs outline-none appearance-none w-full border bg-white',
               {
                 'border-light hover:border-medium focus:border-gray-9':
                   !isDisabled &&
@@ -359,14 +359,14 @@ $: {
                 on:mouseleave={clearNavigationIndex}
               >
                 {#if heading}
-                  <span class="flex text-sm text-default pl-2 py-1 flex-wrap">
+                  <span class="flex text-xs text-default pl-1.5 py-1 flex-wrap">
                     {heading}
                   </span>
                 {/if}
                 {#each searchedOptions as { search, option }, index (option)}
                   <label
                     class={cx(
-                      'flex w-full gap-2 text-ellipsis whitespace-nowrap px-2 py-1 text-sm',
+                      'flex w-full gap-2 text-ellipsis whitespace-nowrap px-2 py-1 text-xs',
                       {
                         'bg-light': navigationIndex === index,
                         'text-default': hasPrefix,
@@ -430,7 +430,7 @@ $: {
                 {/each}
                 {#if canClearAll}
                   <button
-                    class="w-full px-2 py-1 hover:bg-light text-sm text-left"
+                    class="w-full px-2 py-1 hover:bg-light text-xs text-left"
                     on:mouseenter={clearNavigationIndex}
                     on:click={handleClearAll}
                   >
@@ -439,7 +439,7 @@ $: {
                 {/if}
               </div>
             {:else}
-              <div class="flex py-1 px-2.5 justify-center text-sm">
+              <div class="flex py-1 px-2.5 justify-center text-xs">
                 No matching results
               </div>
             {/if}

--- a/src/elements/select/select.svelte
+++ b/src/elements/select/select.svelte
@@ -226,7 +226,7 @@ $: {
     {#if label}
       <p
         class={cx('text-xs', {
-          'text-subtle-1': !isDisabled && !isReadonly,
+          'text-xsbtle-1': !isDisabled && !isReadonly,
           'text-disabled-dark': isDisabled || isReadonly,
           'inline whitespace-nowrap': labelposition === 'left',
         })}
@@ -259,7 +259,7 @@ $: {
           readonly={isDisabled || isReadonly ? true : undefined}
           type="text"
           class={cx(
-            'py-1 pl-2 pr-1 grow text-sm outline-none appearance-none w-full border bg-white',
+            'pl-2 py-1.5 pr-1 grow text-xs outline-none appearance-none w-full border bg-white',
             {
               'border-light hover:border-medium focus:border-gray-9':
                 !isDisabled &&
@@ -314,14 +314,14 @@ $: {
             on:mouseleave={clearNavigationIndex}
           >
             {#if heading}
-              <span class="flex text-sm text-default pl-2 py-1 flex-wrap">
+              <span class="flex text-xs text-default pl-2 py-1 flex-wrap">
                 {heading}
               </span>
             {/if}
             {#each searchedOptions as { search, option }, index (option)}
               <label
                 class={cx(
-                  'flex w-full gap-2 text-ellipsis whitespace-nowrap px-2 py-1 text-sm',
+                  'flex w-full gap-2 text-ellipsis whitespace-nowrap px-2 py-1.5 text-xs',
                   {
                     'bg-light': navigationIndex === index,
                     'text-default': hasPrefix,
@@ -383,7 +383,7 @@ $: {
             {/each}
           </div>
         {:else}
-          <div class="flex py-1 px-2 justify-center text-sm">
+          <div class="flex py-1 px-2 justify-center text-xs">
             No matching results
           </div>
         {/if}


### PR DESCRIPTION
Requesting some PRIME changes as discussed:

button

text-xs px-3 py-1.5 
for buttons with icons, side padding should be pl-2 pr-3 instead of px-3
radio

for the text on the actual switches (not the label): text-xs px-3 py-1.5
input

for the text in the input (not the label): text-xs px-2 py-1.5
select/multiselect

for the text in the input (not the label): text-xs pl-2 py-1.5
for the options in the dropdown panel: text-xs py-1.5
(Basically, just making all the font in those components 12px and adjusting side padding as needed. All the components should remain 30px in height.)