### PR TITLE
APP-2027 Add focus delegation for v-input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -31,14 +31,17 @@ setTimeout(() => {
 let leftOptions = $ref("one,two,three,ten")
 let rightOptions = $ref("four,five,six,eight,nine")
 let selectInput = $ref("")
+
+const inputToFocus = $ref<HTMLElement>();
+
 </script>
 
 <template>
   <div class="my-10">
     <v-button 
       variant="success"
-      disabled="false"
-      label="testing"/>
+      label="focus input component"
+      @click="inputToFocus!.focus()"/>
     <v-button 
       variant="success"
       disabled="true"
@@ -61,8 +64,10 @@ let selectInput = $ref("")
       :value="lazyValue"
     />
     <v-input
+      ref="inputToFocus"
+      placeholder="focus me!"
       class="w-full"
-      type="time"
+      type="text"
     />
   </div>
 

--- a/src/elements/input/input.ts
+++ b/src/elements/input/input.ts
@@ -3,6 +3,9 @@ import './input.svelte';
 // https://github.com/sveltejs/svelte/issues/7596
 class Input extends (customElements.get('v-input-internal')!) {
   static override formAssociated = true;
+  override focus() {
+    this.shadowRoot?.querySelector('input')?.focus();
+  }
 }
 
 customElements.define('v-input', Input);


### PR DESCRIPTION
talked with @micheal-parks and found out that the `focus()` event override works, but the focus might be blocked because it is not allowed to be called on page load (must be triggered by user event)

moving forward: adding this update to PRIME and will experiment in app to see if focus will respond `onMount()` on a component that appears after a page load (modal open)