### PR TITLE
Reset toast notifications rather than duplicating them

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.2.18",
+  "version": "0.2.19",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/src/elements/notification/container.component
+++ b/src/elements/notification/container.component
@@ -22,7 +22,7 @@
       out:fade
       animate:flip={{ duration: 200 }}
     >
-      <Toast {item} />
+      <Toast {item} reset={item.reset} />
     </li>
   {/each}
 </ul>

--- a/src/elements/notification/item.component
+++ b/src/elements/notification/item.component
@@ -6,13 +6,27 @@
   import { type SvelteToastOptions, defaults } from './stores'
 
   export let item: SvelteToastOptions
+  export let reset: number
 
   let next = item.initial!
   let prev = next
   let paused = false
+  let lastReset: number
 
-  const progress = tweened(item.initial, { duration: item.duration ?? defaults.duration!, easing: linear })
-  
+  const progress = tweened(item.initial, { duration: item.duration ?? defaults.duration!, easing: linear });
+
+  $: if (reset !== lastReset) {
+    ;(async () => {
+      await progress.set(item.initial, { duration: 100 })
+      paused = true
+      resume()
+      lastReset = reset;
+    })()
+    
+  }
+
+  $: if ($progress === 0) autoclose();
+
   const close = () => toast.pop(item.id!)
   
   const autoclose = () => ($progress === 1 || $progress === 0) && close()
@@ -28,8 +42,8 @@
     if (paused) {
       const d = item.duration!
       const duration = d - d * (($progress - prev) / (next - prev))
-      progress.set(next, { duration }).then(autoclose)
       paused = false
+      progress.set(next, { duration })
     }
   }
 
@@ -41,13 +55,12 @@
     next = item.next!
     prev = $progress
     paused = false
-    progress.set(next).then(autoclose)
+    progress.set(next)
   }
 
   const handleVisibilityChange = () => (document.hidden ? pause() : resume())
 
   onMount(() => {
-    console.log('here')
     document.addEventListener('visibilitychange', handleVisibilityChange)
     handleVisibilityChange()
   })

--- a/src/elements/notification/stores.ts
+++ b/src/elements/notification/stores.ts
@@ -28,6 +28,7 @@ export interface SvelteToastOptions {
   intro?: FlyParams;
   // callback that runs on toast dismiss
   onpop?: (id: number) => void;
+  reset?: number
 }
 
 type PartialOptions = Partial<SvelteToastOptions>;
@@ -84,9 +85,20 @@ const createToast = () => {
       ...config,
       ...param,
       id: count,
+      reset: 0,
     };
 
-    update((value) => (entry.reversed ? [...value, entry] : [entry, ...value]));
+    update((value) => {
+      const match = value.find(item => item.title === entry.title && item.message === entry.message)
+
+      if (match) {
+        value.splice(value.indexOf(match), 1);
+        match.reset! += 1;
+        return match.reversed ? [...value, match] : [match, ...value];
+      }
+
+      return entry.reversed ? [...value, entry] : [entry, ...value];
+    });
 
     return count;
   };

--- a/src/elements/notification/stores.ts
+++ b/src/elements/notification/stores.ts
@@ -28,7 +28,7 @@ export interface SvelteToastOptions {
   intro?: FlyParams;
   // callback that runs on toast dismiss
   onpop?: (id: number) => void;
-  reset?: number
+  reset?: number;
 }
 
 type PartialOptions = Partial<SvelteToastOptions>;
@@ -89,7 +89,9 @@ const createToast = () => {
     };
 
     update((value) => {
-      const match = value.find(item => item.title === entry.title && item.message === entry.message)
+      const match = value.find(
+        (item) => item.title === entry.title && item.message === entry.message
+      );
 
       if (match) {
         value.splice(value.indexOf(match), 1);

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,8 +1,6 @@
 import { ToastContainer, toast } from '../elements/notification';
 
-export default new ToastContainer({
-  target: document.body,
-});
+export default new ToastContainer({ target: document.body });
 
 const info = (title: string, message?: string) => {
   toast.push({ title, message });


### PR DESCRIPTION
This PR changes the behavior of toasts so that if a duplicate message is pushed, an existing toast will reset its timer and migrate to the top of the list rather than stacking duplicate messages.

![toasts](https://github.com/viamrobotics/prime/assets/103450731/16ada54f-308a-4fd4-b924-8121a052c6c3)

