### PR TITLE
20230718_Update Code Snippet to match v-button padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/src/elements/code-snippet.svelte
+++ b/src/elements/code-snippet.svelte
@@ -105,12 +105,12 @@ $: {
 </script>
 
 <div
-  class={cx('flex gap-x-4 p-2', {
+  class={cx('flex gap-x-4 p-1.5', {
     '!bg-gray-9': theme === 'vsc-dark-plus',
     '!bg-light': theme === 'vs',
   })}
 >
-  <pre class="flex-1 !bg-inherit !border-none !m-0 !p-0 !pt-2 !pl-2"><code
+  <pre class="flex-1 !bg-inherit !border-none !m-0 !p-0 !pt-1.5 !pl-2"><code
       bind:this={element}
       class="language-{language} font-mono">{code}</code
     ></pre>


### PR DESCRIPTION
**20230718_Update Code Snippet to match v-button padding**

Currently the copy organization ID button in the organization settings page utilizes the v-input.  However, I need to switch it out for the code snippet component.  However I'm having some height issues.   See below.

<img width="712" alt="Screen Shot 2023-07-18 at 11 23 36 AM" src="https://github.com/viamrobotics/prime/assets/83609116/d61b8aa2-9627-4f6d-a45a-66a5ea29dbb9">

**I think this PR should fix my issue, but can you please advise?**
