### PR TITLE
Add duplicate icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "license": "Apache-2.0",
   "type": "module",
   "files": [
@@ -50,7 +50,7 @@
     "@storybook/addon-actions": "^7.0.7",
     "@storybook/addon-docs": "^7.0.7",
     "@storybook/addon-essentials": "^7.0.7",
-    "@storybook/addon-interactions": "^7.0.7",
+    "@storybook/addon-interactions": "^7.0.7", 
     "@storybook/addon-links": "^7.0.7",
     "@storybook/addons": "^7.0.7",
     "@storybook/blocks": "^7.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@storybook/addon-actions": "^7.0.7",
     "@storybook/addon-docs": "^7.0.7",
     "@storybook/addon-essentials": "^7.0.7",
-    "@storybook/addon-interactions": "^7.0.7", 
+    "@storybook/addon-interactions": "^7.0.7",
     "@storybook/addon-links": "^7.0.7",
     "@storybook/addons": "^7.0.7",
     "@storybook/blocks": "^7.0.7",

--- a/src/elements/icon/icons.ts
+++ b/src/elements/icon/icons.ts
@@ -48,6 +48,7 @@ import {
   mdiArrowExpandRight,
   mdiArrowCollapseLeft,
   mdiArrowCollapseRight,
+  mdiContentDuplicate,
 } from '@mdi/js';
 
 export const paths: Record<string, string> = {
@@ -85,6 +86,7 @@ export const paths: Record<string, string> = {
   'check-circle': mdiCheckCircle,
   'chevron-down': mdiChevronDown,
   'content-copy': mdiContentCopy,
+  'content-duplicate': mdiContentDuplicate,
   'content-save-outline': mdiContentSaveOutline,
   'credit-card-outline': mdiCreditCardOutline,
   'dots-horizontal': mdiDotsHorizontal,

--- a/src/stories/icon.stories.mdx
+++ b/src/stories/icon.stories.mdx
@@ -70,6 +70,7 @@ import { paths } from '../elements/icon/icons';
   <v-icon name='close'></v-icon>
   <v-icon name='cog'></v-icon>
   <v-icon name='content-copy'></v-icon>
+  <v-icon name='content-duplicate'></v-icon>
   <v-icon name='content-save-outline'></v-icon>
   <v-icon name='credit-card-outline'></v-icon>
   <v-icon name='dots-horizontal'></v-icon>


### PR DESCRIPTION
**Adds Duplicate Icon**

Adds a duplicate icon into PRIME.  
Icon necessary for FE work to duplicate a component.

Ticket: https://viam.atlassian.net/browse/APP-419

Figma: https://www.figma.com/file/XLsscBRMdg6kUKHVNSzXOA/Robot-Details-%3E-Config?type=design&node-id=4113-56359&mode=design&t=Dm8En71PgFNrhEtX-0