### PR TITLE
APP-2283 Migrate Breadcrumbs to @viamrobotics/prime-core

### DIFF
--- a/packages/core/src/lib/breadcrumbs.spec.ts
+++ b/packages/core/src/lib/breadcrumbs.spec.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Breadcrumbs from './breadcrumbs.svelte';
+
+describe('Breadcrumbs', () => {
+  it('Renders breadcrumbs with the list of values specified in crumbs attribute as pills', () => {
+    render(Breadcrumbs, { crumbs: ['Chocolate Chip', 'Oatmeal Raisin'] });
+    expect(screen.getByText('Chocolate Chip')).toBeInTheDocument();
+    expect(screen.getByText('Oatmeal Raisin')).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/lib/breadcrumbs.svelte
+++ b/packages/core/src/lib/breadcrumbs.svelte
@@ -1,0 +1,25 @@
+<svelte:options immutable />
+
+<script lang="ts">
+export let crumbs: string[];
+</script>
+
+<div
+  class="inline-flex gap-2.5 rounded-full border border-medium bg-light px-3 py-px text-default"
+>
+  {#each crumbs as crumb, index (crumb)}
+    <small class="text-xs">
+      {crumb}
+    </small>
+    {#if index !== crumbs.length - 1}
+      <div>
+        <div
+          class="-mt-0.5 h-[69%] w-px -rotate-[30deg] border-l border-medium"
+        />
+        <div
+          class="-mt-0.5 h-[69%] w-px rotate-[30deg] border-l border-medium"
+        />
+      </div>
+    {/if}
+  {/each}
+</div>

--- a/packages/core/src/lib/breadcrumbs.svelte
+++ b/packages/core/src/lib/breadcrumbs.svelte
@@ -1,7 +1,19 @@
+<!--
+@component
+  
+A navigation aid that helps users understand the relationships between parents and children.
+
+```svelte
+<Breadcrumbs crumbs={['Dessert', 'Cookie']} />
+```
+-->
 <svelte:options immutable />
 
 <script lang="ts">
-export let crumbs: string[];
+/**
+ * A list of each part.
+ */
+export let crumbs: [string, ...string[]];
 </script>
 
 <div

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,1 +1,2 @@
 export { default as Badge } from './badge.svelte';
+export { default as Breadcrumbs } from './breadcrumbs.svelte';

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import Badge from '$lib/badge.svelte';
+import Breadcrumbs from '$lib/breadcrumbs.svelte';
 </script>
 
 <!-- Badge -->
@@ -23,3 +24,6 @@ import Badge from '$lib/badge.svelte';
   variant="blue"
   label="Info"
 />
+
+<!-- Breadcrumbs -->
+<Breadcrumbs crumbs={['Chocolate Chip', 'Oatmeal Raisin']} />

--- a/packages/storybook/src/stories/breadcrumbs.stories.mdx
+++ b/packages/storybook/src/stories/breadcrumbs.stories.mdx
@@ -1,0 +1,30 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { Breadcrumbs } from '@viamrobotics/prime-core';
+
+<Meta
+  title='Elements/Breadcrumbs'
+  argTypes={{
+    crumbs: {
+      description: 'A list of breadcrumbs',
+      table: { defaultValue: { summary: '' } },
+    },
+  }}
+/>
+
+# Breadcrumbs
+
+A navigation aid that helps users easily understand the relation between parents and children
+
+<Canvas>
+  <Story
+    name='Breadcrumbs'
+    args={{
+      crumbs: ['Crumb 1', 'Crumb 2'],
+    }}
+  >
+    {(props) => ({
+      Component: Breadcrumbs,
+      props,
+    })}
+  </Story>
+</Canvas>


### PR DESCRIPTION
Migrates Breadcrumbs component to `@viamrobotics/prime-core`.

## Change log

- Copy `breadcrumbs.svelte` to `packages/core`
    - Change props to accept an array
- Add `Breadcrumbs` export from `index.ts`
- Copy unit tests
    - Change to use vitest
- Copy storybook story to `packages/storybook`
    - Change to use Svelte component directly

## Testing

- Added unit tests

## Review requests

- None