### PR TITLE
Document badge component

### DIFF
--- a/packages/core/src/lib/badge.svelte
+++ b/packages/core/src/lib/badge.svelte
@@ -1,12 +1,29 @@
+<!--
+  @component
+  
+  The badge is often used to display status information.
+
+  ```svelte
+  <Badge
+    variant='green'
+    label='Active'
+  />
+  ```
+-->
 <svelte:options immutable />
 
 <script lang="ts">
-type Variants = 'green' | 'orange' | 'red' | 'gray' | 'blue';
-
 import cx from 'classnames';
 
+/**
+ * The badge text.
+ */
 export let label = '';
-export let variant: Variants = 'gray';
+
+/**
+ * The color theme of the badge.
+ */
+export let variant: 'green' | 'orange' | 'red' | 'gray' | 'blue' = 'gray';
 </script>
 
 <small


### PR DESCRIPTION
Setting up an example for component documentation 🎉 

Note: it would be cool to somehow export the @component docs to storybook, but haven't thought of a simple way to do that yet.