### PR TITLE
Add label to core

### DIFF
--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,6 +1,7 @@
 export { default as Badge } from './badge.svelte';
 export { default as Breadcrumbs } from './breadcrumbs.svelte';
 export { default as Button } from './button.svelte';
+export { default as Label } from './label.svelte';
 export { default as Pill } from './pill.svelte';
 export {
   default as Tooltip,

--- a/packages/core/src/lib/label.spec.svelte
+++ b/packages/core/src/lib/label.spec.svelte
@@ -1,0 +1,24 @@
+<!-- 
+  @component
+
+  This component allows us to render a Label with its slotted
+  children, due to limitations with rendering slots using
+  `@testing-library`.
+
+  See:
+  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
+  - https://github.com/testing-library/svelte-testing-library/issues/48
+ -->
+<script lang="ts">
+import Label from './label.svelte';
+
+export let disabled = false;
+export let required = false;
+</script>
+
+<Label
+  {disabled}
+  {required}
+>
+  Name:
+</Label>

--- a/packages/core/src/lib/label.spec.ts
+++ b/packages/core/src/lib/label.spec.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Label from './label.spec.svelte';
+
+describe('Label', () => {
+  it('Renders the Label', () => {
+    render(Label);
+
+    const label = screen.getByText('Name:');
+    expect(label).toHaveClass('text-xs text-subtle-1');
+    expect(label).not.toHaveClass('inline whitespace-nowrap');
+  });
+
+  it('Renders the Label text as disabled', () => {
+    render(Label, { disabled: true });
+    expect(screen.getByText('Name:')).toHaveClass(
+      'text-xs pointer-events-none text-disabled-dark'
+    );
+  });
+
+  it('Renders the Label text as required', () => {
+    render(Label, { required: true });
+    expect(screen.getByText('Name:')).toHaveClass(
+      'after:ml-1 after:text-danger-dark after:content-["*"]'
+    );
+  });
+});

--- a/packages/core/src/lib/label.svelte
+++ b/packages/core/src/lib/label.svelte
@@ -1,0 +1,33 @@
+<!-- 
+  @component
+  
+  For labelling inputs
+  
+```svelte
+<Label>
+  Name:
+  <Input name="name" />
+</Label>
+```
+ -->
+<svelte:options immutable />
+
+<script lang="ts">
+import cx from 'classnames';
+
+/** Whether or not the label should render as required */
+export let required = false;
+
+/** Whether or not the label should render as disabled */
+export let disabled = false;
+</script>
+
+<label
+  class={cx('text-xs', {
+    'text-subtle-1': !disabled,
+    'pointer-events-none text-disabled-dark': disabled,
+    'after:ml-1 after:text-danger-dark after:content-["*"]': required,
+  })}
+>
+  <slot />
+</label>

--- a/packages/core/src/lib/tooltip.svelte
+++ b/packages/core/src/lib/tooltip.svelte
@@ -37,23 +37,28 @@ export let location: TooltipLocation = 'top';
  */
 export let state: TooltipState = 'invisible';
 
-let container: HTMLElement;
-let tooltip: HTMLElement;
-let arrowElement: HTMLElement;
+let container: HTMLElement | undefined;
+let tooltip: HTMLElement | undefined;
+let arrowElement: HTMLElement | undefined;
 
 let invisible = true;
 
 let x = 0;
 let y = 0;
+let arrowCss = '';
 
 export let recalculateStyle = async () => {
+  if (container === undefined || tooltip === undefined) {
+    return;
+  }
+
   const position = await computePosition(container, tooltip, {
     placement: location,
     middleware: [
       offset(7),
       flip(),
       shift({ padding: 5 }),
-      arrow({ element: arrowElement }),
+      arrowElement ? arrow({ element: arrowElement }) : undefined,
     ],
   });
 
@@ -68,8 +73,7 @@ export let recalculateStyle = async () => {
   const arrowX = position.middlewareData.arrow?.x ?? 0;
   const arrowY = position.middlewareData.arrow?.y ?? 0;
 
-  /* eslint-disable-next-line require-atomic-updates */
-  arrowElement.style.cssText =
+  arrowCss =
     staticSide === 'right' || staticSide === 'left'
       ? `
       top: ${arrowY}px;
@@ -89,8 +93,8 @@ export let recalculateStyle = async () => {
 };
 
 const show = async () => {
-  await recalculateStyle();
   invisible = false;
+  await recalculateStyle();
 };
 
 const hide = () => {
@@ -107,6 +111,12 @@ $: {
   /* eslint-disable-next-line no-console */
   recalculateStyle().catch(console.error);
 }
+
+$: {
+  if (arrowElement !== undefined) {
+    arrowElement.style.cssText = arrowCss;
+  }
+}
 </script>
 
 <button
@@ -119,6 +129,7 @@ $: {
   on:blur={hide}
 >
   <slot />
+  <slot name="icon" />
 </button>
 
 <div
@@ -134,6 +145,7 @@ $: {
     class="absolute h-0 w-0 border-b-[6px] border-l-[6px] border-r-[6px] border-b-gray-9 border-l-transparent border-r-transparent"
   />
 
-  <slot name="icon" />
-  <slot name="text" />
+  {#if !invisible}
+    <slot name="text" />
+  {/if}
 </div>

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 import Badge from '$lib/badge.svelte';
 import Breadcrumbs from '$lib/breadcrumbs.svelte';
 import Button from '$lib/button.svelte';
+import Label from '$lib/label.svelte';
 import Pill from '$lib/pill.svelte';
 import Tooltip from '$lib/tooltip.svelte';
 
@@ -52,6 +53,33 @@ let buttonClickedTimes = 0;
   label="testing 3"
   width="full"
 />
+
+<!-- Label -->
+<Label
+  >Name:
+  <input
+    name="name"
+    class="border border-black"
+  />
+</Label>
+
+<Label required>
+  Name:
+  <input
+    name="name"
+    class="border border-black"
+    required
+  />
+</Label>
+
+<Label disabled>
+  Name:
+  <input
+    name="name"
+    class="border border-black"
+    disabled
+  />
+</Label>
 
 <!-- Pill -->
 

--- a/packages/storybook/src/stories/label/label.stories.mdx
+++ b/packages/storybook/src/stories/label/label.stories.mdx
@@ -1,0 +1,31 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import WithInput from './with-input.svelte';
+
+<Meta
+  title='Elements/Label'
+  argTypes={{
+    disabled: {
+      description: 'Whether to render the label as disabled or not',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: false } },
+    },
+    required: {
+      description: 'Whether to render the label as required or not',
+      control: { type: 'boolean' },
+      table: { defaultValue: { summary: false } },
+    },
+  }}
+/>
+
+# Label
+
+For labelling inputs
+
+<Canvas>
+  <Story name='With Input'>
+    {(props) => ({
+      Component: WithInput,
+      props,
+    })}
+  </Story>
+</Canvas>

--- a/packages/storybook/src/stories/label/with-input.svelte
+++ b/packages/storybook/src/stories/label/with-input.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+import { Label } from '@viamrobotics/prime-core';
+
+export let disabled = false;
+export let required = false;
+</script>
+
+<Label
+  {disabled}
+  {required}
+>
+  Name:
+  <input
+    name="name"
+    class="border border-black"
+    placeholder="Enter your name"
+    {disabled}
+    {required}
+  />
+</Label>


### PR DESCRIPTION
This PR adds a new element to `core`, the `Label`. This is the first step of migrating the `Input` to core, by first breaking it apart from its wrapping `Label` to simplify both components. This PR also includes fixes to the tooltip to make sure it works as expected inside of a `Label` (making sure the tooltip text is not read aloud as a part of the label text.)

