### PR TITLE
APP-2288 Add context menu to core

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/context-menu/context-menu-item.svelte
+++ b/packages/core/src/lib/context-menu/context-menu-item.svelte
@@ -1,0 +1,59 @@
+<svelte:options immutable />
+
+<script
+  lang="ts"
+  context="module"
+>
+export type ContextMenuItemVariant = 'primary' | 'danger';
+</script>
+
+<script lang="ts">
+import cx from 'classnames';
+import { createEventDispatcher } from 'svelte';
+import { default as Icon } from '$lib/icon/icon.svelte';
+
+const dispatch = createEventDispatcher<{
+  /** Fires when selected with the label */
+  select: { value: string };
+}>();
+
+/**
+ * Optional icon name (https://prime.viam.com/?path=/docs/elements-icon--docs).
+ * No icon by default.
+ */
+export let icon = '';
+
+/** The style variant, default value is 'primary' */
+export let variant: ContextMenuItemVariant = 'primary';
+
+/** The text displayed. */
+export let label: string;
+</script>
+
+<button
+  role="menuitem"
+  aria-labelledby={label}
+  class="flex w-full items-center gap-1 px-2 py-1.5 text-left hover:bg-light"
+  on:click={() => dispatch('select', { value: label })}
+>
+  {#if icon !== ''}
+    <div
+      class={cx({
+        'text-gray-400': variant === 'primary',
+        'text-danger-dark': variant === 'danger',
+      })}
+    >
+      <Icon name={icon} />
+    </div>
+  {/if}
+
+  <p
+    id={label}
+    class={cx('text-sm', {
+      'text-default': variant === 'primary',
+      'text-danger-dark': variant === 'danger',
+    })}
+  >
+    {label}
+  </p>
+</button>

--- a/packages/core/src/lib/context-menu/context-menu-separator.svelte
+++ b/packages/core/src/lib/context-menu/context-menu-separator.svelte
@@ -1,0 +1,3 @@
+<svelte:options immutable />
+
+<hr class="mb-0.5 mt-1 border-light drop-shadow-none" />

--- a/packages/core/src/lib/context-menu/context-menu.spec.svelte
+++ b/packages/core/src/lib/context-menu/context-menu.spec.svelte
@@ -1,0 +1,24 @@
+<!-- 
+  @component
+
+  This component allows us to render a Tooltip with its slotted
+  children, due to limitations with rendering slots using
+  `@testing-library`.
+
+  See:
+  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
+  - https://github.com/testing-library/svelte-testing-library/issues/48
+ -->
+<script lang="ts">
+import ContextMenu from './context-menu.svelte';
+import ContextMenuItem from './context-menu-item.svelte';
+import ContextMenuSeparator from './context-menu-separator.svelte';
+</script>
+
+<ContextMenu>
+  <ContextMenuItem
+    label="hello"
+    icon="plus"
+  />
+  <ContextMenuSeparator />
+</ContextMenu>

--- a/packages/core/src/lib/context-menu/context-menu.spec.ts
+++ b/packages/core/src/lib/context-menu/context-menu.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import ContextMenuItem from './context-menu-item.svelte';
+import ContextMenuSeparator from './context-menu-separator.svelte';
+
+describe('Context menu', () => {
+  it('Renders context menu item', () => {
+    render(ContextMenuItem, { label: 'label' });
+    expect(screen.getByText('label')).toBeVisible();
+  });
+
+  it('Renders context menu item with icon', () => {
+    render(ContextMenuItem, { label: 'primary', icon: 'close' });
+    expect(screen.getByRole('img', { name: 'close icon' })).toBeVisible();
+  });
+
+  it('Renders context menu separator', () => {
+    render(ContextMenuSeparator);
+    expect(screen.getByRole('separator')).toBeVisible();
+  });
+
+  it('Renders style variants', () => {
+    render(ContextMenuItem, { label: 'label' });
+    expect(screen.getByText('label')).toHaveClass('text-default');
+
+    render(ContextMenuItem, { label: 'primary', variant: 'primary' });
+    expect(screen.getByText('primary')).toHaveClass('text-default');
+
+    render(ContextMenuItem, { label: 'danger', variant: 'danger' });
+    expect(screen.getByText('danger')).toHaveClass('text-danger-dark');
+  });
+
+  it('Dispatches select events', async () => {
+    const { component } = render(ContextMenuItem, {
+      label: 'select me!',
+      icon: 'arrow-up',
+    });
+    const onSelect = vi.fn();
+    component.$on('select', onSelect);
+
+    await fireEvent.click(screen.getByRole('menuitem'));
+    expect(onSelect).toHaveBeenCalledOnce();
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ detail: { value: 'select me!' } })
+    );
+
+    await fireEvent.click(screen.getByText('select me!'));
+    expect(onSelect).toHaveBeenCalledTimes(2);
+
+    await fireEvent.click(screen.getByRole('img', { name: 'arrow-up icon' }));
+    expect(onSelect).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/core/src/lib/context-menu/context-menu.spec.ts
+++ b/packages/core/src/lib/context-menu/context-menu.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/svelte';
 import ContextMenuItem from './context-menu-item.svelte';
 import ContextMenuSeparator from './context-menu-separator.svelte';
+import ContextMenu from './context-menu.spec.svelte';
 
 describe('Context menu', () => {
   it('Renders context menu item', () => {
@@ -49,5 +50,12 @@ describe('Context menu', () => {
 
     await fireEvent.click(screen.getByRole('img', { name: 'arrow-up icon' }));
     expect(onSelect).toHaveBeenCalledTimes(3);
+  });
+
+  it('Renders context menu slots', () => {
+    render(ContextMenu);
+    expect(screen.getByText('hello')).toBeVisible();
+    expect(screen.getByRole('img', { name: 'plus icon' })).toBeVisible();
+    expect(screen.getByRole('separator')).toBeVisible();
   });
 });

--- a/packages/core/src/lib/context-menu/context-menu.svelte
+++ b/packages/core/src/lib/context-menu/context-menu.svelte
@@ -1,0 +1,8 @@
+<svelte:options immutable />
+
+<div
+  role="menu"
+  class="max-w-xs border border-medium py-1 shadow-sm"
+>
+  <slot class="filter-none" />
+</div>

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -18,3 +18,6 @@ export {
   default as TextInput,
   type TextInputTypes,
 } from './input/text-input.svelte';
+export { default as ContextMenu } from './context-menu/context-menu.svelte';
+export { default as ContextMenuItem } from './context-menu/context-menu-item.svelte';
+export { default as ContextMenuSeparator } from './context-menu/context-menu-separator.svelte';

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -2,6 +2,9 @@
 import Badge from '$lib/badge.svelte';
 import Breadcrumbs from '$lib/breadcrumbs.svelte';
 import Button from '$lib/button.svelte';
+import ContextMenu from '$lib/context-menu/context-menu.svelte';
+import ContextMenuItem from '$lib/context-menu/context-menu-item.svelte';
+import ContextMenuSeparator from '$lib/context-menu/context-menu-separator.svelte';
 import Icon from '$lib/icon/icon.svelte';
 import Label from '$lib/label.svelte';
 import Input from '$lib/input/input.svelte';
@@ -374,4 +377,22 @@ let buttonClickedTimes = 0;
       label="readonly"
     />
   </div>
+  <!-- Context menu -->
+  <ContextMenu>
+    <ContextMenuItem label="label 1" />
+    <ContextMenuSeparator />
+    <ContextMenuItem
+      label="label 2"
+      variant="primary"
+    />
+    <ContextMenuItem
+      icon="trash-can-outline"
+      label="label 3"
+    />
+    <ContextMenuItem
+      icon="close"
+      label="danger"
+      variant="danger"
+    />
+  </ContextMenu>
 </div>

--- a/packages/legacy/src/stories/context-menu.stories.mdx
+++ b/packages/legacy/src/stories/context-menu.stories.mdx
@@ -10,12 +10,12 @@ import { Canvas, Meta, Story } from '@storybook/addon-docs';
       table: { defaultValue: { summary: 'primary' } },
     },
     labels: {
-      description: 'The item labels',
+      description: 'The item label',
       control: { type: 'input' },
     },
     icon: {
       description: 'The item icon',
-      control: { teyp: 'input' },
+      control: { type: 'input' },
       table: { defaultValue: { summary: '' } },
     },
   }}

--- a/packages/storybook/src/stories/context-menu/context-menu.stories.mdx
+++ b/packages/storybook/src/stories/context-menu/context-menu.stories.mdx
@@ -1,0 +1,107 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import {
+  ContextMenuItem,
+  ContextMenuSeparator,
+} from '@viamrobotics/prime-core';
+import ContextMenu from './context-menu.svelte';
+
+<Meta
+  title='Elements/Context menu'
+  argTypes={{
+    variant: {
+      description: 'The item color',
+      control: { type: 'select' },
+      options: ['primary', 'danger'],
+      table: { defaultValue: { summary: 'primary' } },
+    },
+    label: {
+      description: 'The item labels',
+      control: { type: 'input' },
+    },
+    icon: {
+      description: 'The item icon',
+      control: { type: 'input' },
+      table: { defaultValue: { summary: '' } },
+    },
+  }}
+/>
+
+# Context menu
+
+To display options for some context. Usually made visible on click (especially right click) and in conjunction with floating-ui.
+
+<Canvas>
+  <Story
+    name='Item'
+    args={{
+      label: 'just a label',
+    }}
+  >
+    {(props) => ({
+      Component: ContextMenuItem,
+      props,
+    })}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Item with icon'
+    args={{
+      label: 'with icon!',
+      icon: 'trash-can-outline',
+    }}
+  >
+    {(props) => ({
+      Component: ContextMenuItem,
+      props,
+    })}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Primary variant (default)'
+    args={{
+      label: '~ primary ~',
+      variant: 'primary',
+    }}
+  >
+    {(props) => ({
+      Component: ContextMenuItem,
+      props,
+    })}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story
+    name='Danger variant (dangerous)'
+    args={{
+      label: '!! DANGER !!',
+      variant: 'danger',
+      icon: 'close',
+    }}
+  >
+    {(props) => ({
+      Component: ContextMenuItem,
+      props,
+    })}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name='Separator'>
+    {() => ({
+      Component: ContextMenuSeparator,
+    })}
+  </Story>
+</Canvas>
+
+<Canvas>
+  <Story name='Full context menu'>
+    {() => ({
+      Component: ContextMenu,
+    })}
+  </Story>
+</Canvas>

--- a/packages/storybook/src/stories/context-menu/context-menu.svelte
+++ b/packages/storybook/src/stories/context-menu/context-menu.svelte
@@ -1,0 +1,33 @@
+<script
+  lang="ts"
+  context="module"
+>
+import {
+  ContextMenu,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  type ContextMenuItemVariant,
+} from '@viamrobotics/prime-core';
+
+export let label: string = 'hi';
+export let variant: ContextMenuItemVariant = 'primary';
+export let icon: string = '';
+</script>
+
+<ContextMenu>
+  <ContextMenuItem
+    {label}
+    {variant}
+    {icon}
+  />
+  <ContextMenuItem
+    label="hello"
+    icon="plus"
+  />
+  <ContextMenuSeparator />
+  <ContextMenuItem
+    label="BYE"
+    icon="close"
+    variant="danger"
+  />
+</ContextMenu>


### PR DESCRIPTION
Adds the context menu component and related elements `<ContextMenuItem />` and `<ContextMenuSeparator />` to core.

Added stories demonstrating ContextMenuItem and ContextMenuSeparator individually, and one example of all elements together as a full ContextMenu

Removed a test related to tab / enter select behavior, as this is implemented by the browser and not testable with vitest. This should be tested with Playwright when we add it into Prime for larger component testing.