### PR TITLE
Add Input and TextInput

### DIFF
--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -5,8 +5,15 @@ export { default as Icon } from './icon/icon.svelte';
 export { default as Label } from './label.svelte';
 export { default as Pill } from './pill.svelte';
 export { default as Radio } from './radio.svelte';
+
 export {
   default as Tooltip,
   type TooltipLocation,
   type TooltipState,
 } from './tooltip.svelte';
+
+export { default as Input } from './input/input.svelte';
+export {
+  default as TextInput,
+  type TextInputTypes,
+} from './input/text-input.svelte';

--- a/packages/core/src/lib/input/input.spec.ts
+++ b/packages/core/src/lib/input/input.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Input from './input.svelte';
+
+describe('Input', () => {
+  it('Renders the input', () => {
+    render(Input, { placeholder: 'Enter your name' });
+
+    const input = screen.getByPlaceholderText('Enter your name');
+
+    expect(input).toHaveClass(
+      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+    );
+
+    expect(input).not.toHaveClass(
+      'bg-disabled-light text-disabled-dark border-disabled-light pointer-events-none'
+    );
+  });
+
+  it('Renders the input as disabled', () => {
+    render(Input, { placeholder: 'Enter your name', disabled: true });
+
+    const input = screen.getByPlaceholderText('Enter your name');
+
+    expect(input).toHaveClass(
+      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+    );
+
+    expect(input).toHaveClass(
+      'bg-disabled-light text-disabled-dark border-disabled-light pointer-events-none'
+    );
+
+    expect(input).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('Renders the input as readonly', () => {
+    render(Input, { placeholder: 'Enter your name', readonly: true });
+
+    const input = screen.getByPlaceholderText('Enter your name');
+
+    expect(input).toHaveClass(
+      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+    );
+
+    expect(input).toHaveClass(
+      'bg-disabled-light text-disabled-dark border-disabled-light'
+    );
+
+    expect(input).not.toHaveAttribute('aria-disabled');
+  });
+});

--- a/packages/core/src/lib/input/input.svelte
+++ b/packages/core/src/lib/input/input.svelte
@@ -1,0 +1,55 @@
+<!--
+@component
+  
+For user inputs.
+
+This is the base input component that accepts all input properties without any 
+additional behaviors attached. Generally, other typed inputs like the 
+NumberInput or DateInput are preferable.
+
+```svelte
+<Input type="email"  on:click={onClick} />
+```
+-->
+<svelte:options immutable />
+
+<script lang="ts">
+import cx from 'classnames';
+
+/** Whether or not the input should be rendered as readonly and be operable. */
+export let readonly = false;
+
+/** Whether or not the input should be rendered as readonly and be non-operable. */
+export let disabled = false;
+</script>
+
+<input
+  {...$$restProps}
+  readonly={disabled || readonly ? true : undefined}
+  aria-disabled={disabled ? true : undefined}
+  class={cx(
+    'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none',
+    {
+      'border-disabled-light bg-disabled-light text-disabled-dark':
+        disabled || readonly,
+      'pointer-events-none': disabled,
+    }
+  )}
+  on:input
+  on:keydown
+  on:focus
+  on:blur
+/>
+
+<style>
+input::-webkit-outer-spin-button,
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+</style>

--- a/packages/core/src/lib/input/text-input.spec.ts
+++ b/packages/core/src/lib/input/text-input.spec.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import Input from './text-input.svelte';
+
+describe('Text Input', () => {
+  it('Renders the input', () => {
+    render(Input, { placeholder: 'Enter your name' });
+    expect(screen.getByPlaceholderText('Enter your name')).toHaveAttribute(
+      'type',
+      'text'
+    );
+  });
+
+  it('Renders the input as an email input', () => {
+    render(Input, { placeholder: 'Enter your email', type: 'email' });
+    expect(screen.getByPlaceholderText('Enter your email')).toHaveAttribute(
+      'type',
+      'email'
+    );
+  });
+
+  it('Renders the input as a password input', () => {
+    render(Input, { placeholder: 'Enter your password', type: 'password' });
+    expect(screen.getByPlaceholderText('Enter your password')).toHaveAttribute(
+      'type',
+      'password'
+    );
+  });
+});

--- a/packages/core/src/lib/input/text-input.svelte
+++ b/packages/core/src/lib/input/text-input.svelte
@@ -1,0 +1,33 @@
+<!--
+@component
+  
+For text-based user inputs.
+
+```svelte
+<TextInput type="email"  on:input={onInput} />
+```
+-->
+<svelte:options immutable />
+
+<script
+  lang="ts"
+  context="module"
+>
+export type TextInputTypes = 'text' | 'email' | 'password';
+</script>
+
+<script lang="ts">
+import Input from './input.svelte';
+
+/** The input type */
+export let type: TextInputTypes = 'text';
+</script>
+
+<Input
+  {...$$restProps}
+  {type}
+  on:input
+  on:keydown
+  on:focus
+  on:blur
+/>

--- a/packages/core/src/lib/tooltip.spec.svelte
+++ b/packages/core/src/lib/tooltip.spec.svelte
@@ -21,10 +21,5 @@ export let state: 'invisible' | 'visible' = 'invisible';
   {state}
 >
   <p>This element has a tooltip.</p>
-  <span
-    slot="icon"
-    role="img"
-    class="information-outline"
-  />
   <p slot="text">This is the tooltip text!</p>
 </Tooltip>

--- a/packages/core/src/lib/tooltip.spec.ts
+++ b/packages/core/src/lib/tooltip.spec.ts
@@ -6,7 +6,6 @@ describe('Tooltip', () => {
   it('Renders the target element without the tooltip', () => {
     render(Tooltip);
     expect(screen.getByText('This element has a tooltip.')).toBeInTheDocument();
-    expect(screen.getByRole('img')).toHaveClass('information-outline');
     expect(screen.getByRole('tooltip')).toHaveClass('invisible');
   });
 

--- a/packages/core/src/lib/tooltip.svelte
+++ b/packages/core/src/lib/tooltip.svelte
@@ -121,7 +121,7 @@ $: {
 
 <button
   bind:this={container}
-  class="inline-block cursor-default"
+  class="flex cursor-default items-center"
   aria-describedby="tooltip"
   on:mouseenter={show}
   on:mouseleave={hide}
@@ -129,7 +129,6 @@ $: {
   on:blur={hide}
 >
   <slot />
-  <slot name="icon" />
 </button>
 
 <div

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -4,9 +4,11 @@ import Breadcrumbs from '$lib/breadcrumbs.svelte';
 import Button from '$lib/button.svelte';
 import Icon from '$lib/icon/icon.svelte';
 import Label from '$lib/label.svelte';
+import Input from '$lib/input/input.svelte';
 import Pill from '$lib/pill.svelte';
 import Radio from '$lib/radio.svelte';
 import Tooltip from '$lib/tooltip.svelte';
+import TextInput from '$lib/input/text-input.svelte';
 
 let buttonClickedTimes = 0;
 </script>
@@ -76,81 +78,146 @@ let buttonClickedTimes = 0;
   </div>
 
   <div class="flex gap-4">
+    <!-- Input -->
+
+    <Input
+      name="name"
+      placeholder="Enter your name"
+    />
+
+    <Input
+      name="name"
+      value="Phillip J. Fry"
+      readonly
+    />
+
+    <Input
+      name="name"
+      value="Phillip J. Fry"
+      disabled
+    />
+
+    <Input
+      name="name"
+      placeholder="Enter your name"
+      required
+    />
+
+    <Input
+      name="name"
+      placeholder="Enter your name (autocomplete)"
+      autocomplete="on"
+    />
+  </div>
+
+  <div class="flex gap-4">
+    <!-- Text Input -->
+
+    <TextInput
+      name="name"
+      placeholder="Enter your name"
+    />
+
+    <TextInput
+      type="email"
+      name="email"
+      placeholder="Enter your email"
+    />
+
+    <TextInput
+      type="password"
+      name="password"
+      placeholder="Enter your password"
+    />
+  </div>
+
+  <div class="flex gap-4">
+    <!-- Numeric Input -->
+
+    <Input
+      type="number"
+      name="number"
+      placeholder="Enter a number"
+    />
+
+    <Input
+      type="integer"
+      name="integer"
+      placeholder="Enter an integer"
+    />
+  </div>
+
+  <div class="flex gap-4">
+    <!-- Datetime Input -->
+
+    <Input
+      type="time"
+      name="time"
+      placeholder="Enter a time"
+    />
+
+    <Input
+      type="date"
+      name="date"
+      placeholder="Enter a date"
+    />
+
+    <Input
+      type="datetime-local"
+      name="datetime-local"
+      placeholder="Enter a date and time"
+    />
+  </div>
+
+  <div class="flex gap-4">
     <!-- Label -->
     <Label
       >Name:
-      <input
+      <Input
         slot="input"
         name="name"
-        class="border border-black"
       />
     </Label>
 
-    <!-- Tooltip -->
-    <Tooltip>
-      This element has a top tooltip.
-      <Icon
-        slot="icon"
-        name="information-outline"
-      />
-      <div slot="text">This is the tooltip text!</div>
-    </Tooltip>
     <Label required>
       Name:
-      <input
+      <Input
         slot="input"
         name="name"
-        class="border border-black"
         required
       />
     </Label>
 
     <Label disabled>
       Name:
-      <input
+      <Input
         slot="input"
         name="name"
-        class="border border-black"
         disabled
       />
     </Label>
   </div>
 
-  <div>
+  <div class="flex gap-4">
     <!-- Tooltip -->
     <Tooltip>
       This element has a top tooltip.
-      <Icon
-        slot="icon"
-        name="information-outline"
-      />
       <div slot="text">This is the tooltip text!</div>
     </Tooltip>
 
     <Tooltip location="left">
       This element has a left tooltip.
-      <Icon
-        slot="icon"
-        name="information-outline"
-      />
       <div slot="text">This is the tooltip text!</div>
     </Tooltip>
 
     <Tooltip location="right">
       This element has a right tooltip.
-      <Icon
-        slot="icon"
-        name="information-outline"
-      />
       <div slot="text">This is the tooltip text!</div>
     </Tooltip>
 
     <Tooltip location="bottom">
-      This element has a bottom tooltip.
-      <Icon
-        slot="icon"
-        name="information-outline"
-      />
+      This element has a bottom tooltip and an icon!
+      <span class="ml-0.5"> <Icon name="information-outline" /></span>
       <div slot="text">This is the tooltip text!</div>
     </Tooltip>
   </div>

--- a/packages/storybook/src/stories/tooltip/plain-text.svelte
+++ b/packages/storybook/src/stories/tooltip/plain-text.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import {
+  Icon,
   Tooltip,
   type TooltipLocation,
   type TooltipState,
@@ -14,10 +15,6 @@ export let state: TooltipState = 'invisible';
   {state}
 >
   <p>This element has a tooltip.</p>
-  <span
-    slot="icon"
-    role="img"
-    class="information-outline"
-  />
+  <Icon name="information-outline" />
   <p slot="text">This is the tooltip text!</p>
 </Tooltip>

--- a/packages/storybook/src/stories/tooltip/rich-html.svelte
+++ b/packages/storybook/src/stories/tooltip/rich-html.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import {
+  Icon,
   Tooltip,
   type TooltipLocation,
   type TooltipState,
@@ -14,11 +15,7 @@ export let state: TooltipState = 'invisible';
   {state}
 >
   <p>This <b>element</b> has a <em>tooltip</em>.</p>
-  <span
-    slot="icon"
-    role="img"
-    class="information-outline"
-  />
+  <Icon name="information-outline" />
   <p slot="text">
     This is the <b class="underline"> tooltip text! </b>
   </p>


### PR DESCRIPTION
Adds the base `<Input />` and `<TextInput />` components to `core`. Does not add stories yet, holding off until all inputs are done to do a more comprehensive story with docs/usage notes. Also did some cleanup on the `<Tooltip />` to remove the `icon` slot and just expect it to be included as a part of the default slot.