### PR TITLE
Fix IconButton size

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/button/icon-button.svelte
+++ b/packages/core/src/lib/button/icon-button.svelte
@@ -56,7 +56,7 @@ const onClick = () => {
   aria-disabled={disabled}
   {title}
   class={cx(
-    'inline-flex h-8 w-8 select-none items-center justify-center whitespace-nowrap',
+    'inline-flex h-[30px] w-[30px] select-none items-center justify-center whitespace-nowrap',
     {
       'text-gray-6 hover:border-medium hover:bg-medium active:bg-gray-2':
         !disabled,


### PR DESCRIPTION
The `IconButton` used to have size `30px x 30px` in legacy, but picked up `32px x 32px` in the migration. This keeps it consistent for the migration.