### PR TITLE
Add use:clickOutside action to prime-core

### DIFF
--- a/packages/core/.eslintrc.cjs
+++ b/packages/core/.eslintrc.cjs
@@ -21,8 +21,10 @@ module.exports = {
     {
       files: '*.svelte',
       rules: {
-        // TODO(mc, 2023-08-28): this rule is crashing with svelte actions
-        // investigate and fix once lint dependencies are updated
+        /*
+         * TODO(mc, 2023-08-28): this rule is crashing with svelte actions.
+         * Investigate and fix once lint dependencies are updated.
+         */
         'sonarjs/no-unused-collection': 'off',
       },
     },

--- a/packages/core/.eslintrc.cjs
+++ b/packages/core/.eslintrc.cjs
@@ -17,4 +17,14 @@ module.exports = {
     'no-undef-init': 'off',
     'unicorn/no-useless-undefined': 'off',
   },
+  overrides: [
+    {
+      files: '*.svelte',
+      rules: {
+        // TODO(mc, 2023-08-28): this rule is crashing with svelte actions
+        // investigate and fix once lint dependencies are updated
+        'sonarjs/no-unused-collection': 'off',
+      },
+    },
+  ],
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,6 +48,7 @@
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^6.0.0",
     "@testing-library/svelte": "^4.0.3",
+    "@testing-library/user-event": "^14.4.3",
     "@types/testing-library__jest-dom": "^5.14.9",
     "@typescript-eslint/eslint-plugin": "^6.4.0",
     "@typescript-eslint/parser": "^6.4.0",

--- a/packages/core/src/lib/__tests__/click-outside.spec.svelte
+++ b/packages/core/src/lib/__tests__/click-outside.spec.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+import { clickOutside } from '$lib';
+
+export let onClickOutside: () => void;
+</script>
+
+<button data-testid="outside" />
+<div
+  data-testid="subject"
+  use:clickOutside={onClickOutside}
+/>

--- a/packages/core/src/lib/__tests__/click-outside.spec.ts
+++ b/packages/core/src/lib/__tests__/click-outside.spec.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+
+import Subject from './click-outside.spec.svelte';
+
+describe('use:clickOutside', () => {
+  const onClickOutside = vi.fn();
+
+  it('should trigger a callback only when clicked outside', async () => {
+    render(Subject, { onClickOutside });
+
+    const user = userEvent.setup();
+    const outsideButton = screen.getByTestId('outside');
+    const subject = screen.getByTestId('subject');
+
+    await user.click(subject);
+
+    expect(onClickOutside).not.toHaveBeenCalled();
+
+    await user.click(outsideButton);
+
+    expect(onClickOutside).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/lib/click-outside.ts
+++ b/packages/core/src/lib/click-outside.ts
@@ -1,0 +1,55 @@
+import type { Action } from 'svelte/action';
+
+/**
+ * Trigger a callback when the user clicks outside the element.
+ *
+ * Use a [Svelte action](https://svelte.dev/docs/svelte-action):
+ * ```svelte
+ * <script lang="ts">
+ * import { writable } from 'svelte/store'
+ * import { clickOutside } from '@viamrobotics/prime-core'
+ *
+ * const isOpen = writable(false)
+ * </script>
+ *
+ * <button on:click={() => isOpen.set(true)}>
+ *   Open Modal
+ * </button>
+ * {#if isOpen}
+ *   <article use:clickOutside={() => isOpen.set(false)}>
+ *     <h3>Cool modal</h3>
+ *   </article>
+ * {/if}
+ * ```
+ *
+ * @param node The DOM node the action is attached to.
+ * @param handler The callback to run
+ * @returns The Svelte Action
+ */
+export const clickOutside: Action<HTMLElement, () => unknown> = (
+  node,
+  handler
+) => {
+  let handleClickOutside = handler;
+
+  const handleWindowClick = (event: MouseEvent): void => {
+    if (
+      node &&
+      !node.contains(event.target as Element | null) &&
+      !event.defaultPrevented
+    ) {
+      handleClickOutside();
+    }
+  };
+
+  window.document.addEventListener('click', handleWindowClick);
+
+  return {
+    update: (nextHandler: () => unknown) => {
+      handleClickOutside = nextHandler;
+    },
+    destroy: () => {
+      window.document.removeEventListener('click', handleWindowClick);
+    },
+  };
+};

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -2,6 +2,7 @@ export { default as Badge } from './badge.svelte';
 export { default as Breadcrumbs } from './breadcrumbs.svelte';
 export { default as Button } from './button/button.svelte';
 export { default as IconButton } from './button/icon-button.svelte';
+export { clickOutside } from './click-outside';
 export { default as Collapse } from './collapse.svelte';
 export { default as Icon } from './icon/icon.svelte';
 export { default as Label, type LabelPosition } from './label.svelte';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@testing-library/svelte':
         specifier: ^4.0.3
         version: 4.0.3(svelte@4.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.4.3
+        version: 14.4.3(@testing-library/dom@9.3.1)
       '@types/testing-library__jest-dom':
         specifier: ^5.14.9
         version: 5.14.9
@@ -5335,7 +5338,7 @@ packages:
       eslint: 8.47.0
       eslint-config-prettier: 9.0.0(eslint@8.47.0)
       eslint-plugin-sonarjs: 0.20.0(eslint@8.47.0)
-      eslint-plugin-svelte: 2.32.4(eslint@8.47.0)(svelte@4.1.2)
+      eslint-plugin-svelte: 2.32.4(eslint@8.47.0)(svelte@4.2.0)
       eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.3)
       eslint-plugin-unicorn: 48.0.1(eslint@8.47.0)
     dev: true
@@ -5370,7 +5373,7 @@ packages:
         optional: true
     dependencies:
       prettier: 3.0.2
-      prettier-plugin-svelte: 3.0.3(prettier@3.0.2)(svelte@4.1.2)
+      prettier-plugin-svelte: 3.0.3(prettier@3.0.2)(svelte@4.2.0)
       prettier-plugin-tailwindcss: 0.5.3(prettier-plugin-svelte@3.0.3)(prettier@3.0.2)
     dev: true
 
@@ -10698,7 +10701,7 @@ packages:
         optional: true
     dependencies:
       prettier: 3.0.2
-      prettier-plugin-svelte: 3.0.3(prettier@3.0.2)(svelte@4.1.2)
+      prettier-plugin-svelte: 3.0.3(prettier@3.0.2)(svelte@4.2.0)
     dev: true
 
   /prettier@2.8.8:


### PR DESCRIPTION
## Overview

@DTCurrie and I have been thinking:

- "do something on click outside" is a common thing across our UIs
- [Svelte actions](https://svelte.dev/docs/svelte-action) (custom `use:...` directives) are the most reliable way to implement this, given reactivity and cleanup concerns
- The [classic click outside action example](https://svelte.dev/repl/0ace7a508bd843b798ae599940a91783?version=3.16.7) does not play nicely with TypeScript 

This PR takes as stab at adding a `clickOutside` action to `@viamrobotics/prime-core` in a type-checking-friendly manner.

```svelte
<script lang="ts">
import { writable } from 'svelte/store'
import { clickOutside } from '@viamrobotics/prime-core'

const isOpen = writable(false)
</script>

<button on:click={() => isOpen.set(true)}>
  Open Menu
</button>
{#if isOpen}
  <article use:clickOutside={() => isOpen.set(false)}>
    <h3>Cool menu</h3>
  </article>
{/if}
```

## Implementation notes

I elected _not_ to use a custom event - as in the example linked above - because it doesn't type-check without adding the custom event to _all_ DOM elements, which feels inaccurate because the event is only emittable if you add the action.

Until working on this, I didn't realize that Svelte actions can take arguments. This resolves the type-checking issue quite nicely and reduces boilerplate. I like how `use:clickOutside` subtly mirrors `on:click`, while making it clear that it's a custom thing that we added:

```svelte
<div
  on:click={() => console.log('hello')}
  use:clickOutside={() => console.log('goodbye')}
/>
```