### PR TITLE
Do not trigger click outside if element is removed from DOM

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/__tests__/click-outside.spec.svelte
+++ b/packages/core/src/lib/__tests__/click-outside.spec.svelte
@@ -8,4 +8,6 @@ export let onClickOutside: () => void;
 <div
   data-testid="subject"
   use:clickOutside={onClickOutside}
-/>
+>
+  <button data-testid="inside" />
+</div>

--- a/packages/core/src/lib/__tests__/click-outside.spec.ts
+++ b/packages/core/src/lib/__tests__/click-outside.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, act } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 
 import Subject from './click-outside.spec.svelte';
@@ -11,15 +11,31 @@ describe('use:clickOutside', () => {
     render(Subject, { onClickOutside });
 
     const user = userEvent.setup();
-    const outsideButton = screen.getByTestId('outside');
     const subject = screen.getByTestId('subject');
+    const insideButton = screen.getByTestId('inside');
+    const outsideButton = screen.getByTestId('outside');
 
     await user.click(subject);
-
+    await user.click(insideButton);
     expect(onClickOutside).not.toHaveBeenCalled();
 
     await user.click(outsideButton);
 
     expect(onClickOutside).toHaveBeenCalledOnce();
+  });
+
+  it('should not trigger if clicked element if it gets removed from the DOM', async () => {
+    render(Subject, { onClickOutside });
+
+    const user = userEvent.setup();
+    const insideButton = screen.getByTestId('inside');
+
+    insideButton.addEventListener('click', () => {
+      insideButton.remove();
+    });
+
+    await user.click(insideButton);
+
+    expect(onClickOutside).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/lib/click-outside.ts
+++ b/packages/core/src/lib/click-outside.ts
@@ -26,7 +26,7 @@ import type { Action } from 'svelte/action';
  * @param handler The callback to run
  * @returns The Svelte Action
  */
-export const clickOutside: Action<HTMLElement, () => unknown> = (
+export const clickOutside: Action<HTMLElement | undefined, () => unknown> = (
   node,
   handler
 ) => {
@@ -35,21 +35,22 @@ export const clickOutside: Action<HTMLElement, () => unknown> = (
   const handleWindowClick = (event: MouseEvent): void => {
     if (
       node &&
-      !node.contains(event.target as Element | null) &&
+      window.document.contains(event.target as Element) &&
+      !node.contains(event.target as Element) &&
       !event.defaultPrevented
     ) {
       handleClickOutside();
     }
   };
 
-  window.document.addEventListener('click', handleWindowClick);
+  window.document.body.addEventListener('click', handleWindowClick);
 
   return {
     update: (nextHandler: () => unknown) => {
       handleClickOutside = nextHandler;
     },
     destroy: () => {
-      window.document.removeEventListener('click', handleWindowClick);
+      window.document.body.removeEventListener('click', handleWindowClick);
     },
   };
 };


### PR DESCRIPTION
Found an interesting edge case with the click-outside action: if you click and element that triggers a state change that causes the element to be removed from the DOM by Svelte, this DOM removal will race with the click event handler.

In the browser (or at least, my browser), Svelte will win and remove the element before the click handler runs. This causes the `node.contains(event.target)` condition to evaluate to false, even though the event target **used to be** in the parent node.

This PR adds an extra check to ensure the clicked event target is in the DOM. I had to get a little creative with the test, since in Node.js / JSDOM, the click handler wins the race. The test I wrote failed before the fix and passed afterwards. It will be covered in-browser by E2E tests in the app.