### PR TITLE
Fix breadcrumb padding and select event handling

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/__tests__/prevent-handler.spec.svelte
+++ b/packages/core/src/lib/__tests__/prevent-handler.spec.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+import { preventHandler, preventKeyboardHandler } from '$lib/prevent-handler';
+
+export let prevent = false;
+export let allowedCodes = ['Tab'];
+
+const handleClick = preventHandler(prevent);
+const handleKeydown = preventKeyboardHandler(prevent, allowedCodes);
+</script>
+
+<button
+  on:click
+  on:click|capture={handleClick}
+  on:keydown
+  on:keydown|capture={handleKeydown}
+>
+  Prevented
+</button>

--- a/packages/core/src/lib/__tests__/prevent-handler.spec.ts
+++ b/packages/core/src/lib/__tests__/prevent-handler.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/svelte';
+import userEvent from '@testing-library/user-event';
+import PreventHandler from './prevent-handler.spec.svelte';
+
+describe('preventHandler', () => {
+  it('Emits the click event', async () => {
+    const onClick = vi.fn();
+    const { component } = render(PreventHandler);
+
+    component.$on('click', onClick);
+
+    const button = screen.getByText('Prevented');
+
+    await userEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('Does not emit the change event when prevent is true', async () => {
+    const onClick = vi.fn();
+    const { component } = render(PreventHandler, { prevent: true });
+
+    component.$on('click', onClick);
+
+    const button = screen.getByText('Prevented');
+
+    await userEvent.click(button);
+
+    expect(onClick).toHaveBeenCalledTimes(0);
+  });
+
+  it('Emits the keydown event', async () => {
+    const onKeydown = vi.fn();
+    const { component } = render(PreventHandler);
+
+    component.$on('keydown', onKeydown);
+
+    const button: HTMLButtonElement = screen.getByText('Prevented');
+    button.focus();
+
+    await userEvent.keyboard('[Enter]');
+
+    expect(onKeydown).toHaveBeenCalledOnce();
+  });
+
+  it('Does not emit the keydown event when prevent is true', async () => {
+    const onKeydown = vi.fn();
+    const { component } = render(PreventHandler, { prevent: true });
+
+    component.$on('keydown', onKeydown);
+
+    const button: HTMLButtonElement = screen.getByText('Prevented');
+    button.focus();
+
+    await userEvent.keyboard('[Enter]');
+
+    expect(onKeydown).toHaveBeenCalledTimes(0);
+  });
+
+  it('Does not emit the keydown event when prevent is true if code is tab', async () => {
+    const onKeydown = vi.fn();
+    const { component } = render(PreventHandler);
+
+    component.$on('keydown', onKeydown);
+
+    const button: HTMLButtonElement = screen.getByText('Prevented');
+    button.focus();
+
+    await userEvent.keyboard('[Tab]');
+
+    expect(onKeydown).toHaveBeenCalledOnce();
+  });
+
+  it('Does not emit the keydown event when prevent is true if code is in allowedCodes', async () => {
+    const onKeydown = vi.fn();
+    const { component } = render(PreventHandler, {
+      prevent: true,
+      allowedCodes: ['Space'],
+    });
+
+    component.$on('keydown', onKeydown);
+
+    const button: HTMLButtonElement = screen.getByText('Prevented');
+    button.focus();
+
+    await userEvent.keyboard('[Space]');
+
+    expect(onKeydown).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/lib/breadcrumbs.svelte
+++ b/packages/core/src/lib/breadcrumbs.svelte
@@ -10,14 +10,12 @@ A navigation aid that helps users understand the relationships between parents a
 <svelte:options immutable />
 
 <script lang="ts">
-/**
- * A list of each part.
- */
+/** A list of each part. */
 export let crumbs: [string, ...string[]];
 </script>
 
 <div
-  class="inline-flex gap-2.5 rounded-full border border-medium bg-light px-3 py-px text-default"
+  class="border-medium bg-light text-default inline-flex gap-2.5 rounded-full border px-2.5 py-px"
 >
   {#each crumbs as crumb, index (crumb)}
     <small class="text-xs">
@@ -26,10 +24,10 @@ export let crumbs: [string, ...string[]];
     {#if index !== crumbs.length - 1}
       <div>
         <div
-          class="-mt-0.5 h-[69%] w-px -rotate-[30deg] border-l border-medium"
+          class="border-medium -mt-0.5 h-[69%] w-px -rotate-[30deg] border-l"
         />
         <div
-          class="-mt-0.5 h-[69%] w-px rotate-[30deg] border-l border-medium"
+          class="border-medium -mt-0.5 h-[69%] w-px rotate-[30deg] border-l"
         />
       </div>
     {/if}

--- a/packages/core/src/lib/button/button.svelte
+++ b/packages/core/src/lib/button/button.svelte
@@ -10,9 +10,9 @@ For user triggered actions.
 <svelte:options immutable />
 
 <script lang="ts">
-import { createEventDispatcher } from 'svelte';
 import cx from 'classnames';
 import { Icon } from '$lib';
+import { preventHandler } from '$lib/prevent-handler';
 
 /** Whether or not the button accepts clicks. */
 export let disabled = false;
@@ -44,15 +44,7 @@ export let width: 'full' | 'default' = 'default';
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
 
-const dispatch = createEventDispatcher<{ click: null }>();
-
-const onClick = () => {
-  if (disabled) {
-    return;
-  }
-
-  dispatch('click');
-};
+const handleDisabled = preventHandler(disabled);
 </script>
 
 <button
@@ -84,7 +76,8 @@ const onClick = () => {
     extraClasses
   )}
   {...$$restProps}
-  on:click={onClick}
+  on:click
+  on:click|capture={handleDisabled}
 >
   {#if icon}
     <span

--- a/packages/core/src/lib/button/icon-button.svelte
+++ b/packages/core/src/lib/button/icon-button.svelte
@@ -10,9 +10,9 @@ For user triggered actions.
 <svelte:options immutable />
 
 <script lang="ts">
-import { createEventDispatcher } from 'svelte';
 import cx from 'classnames';
 import { Icon } from '$lib';
+import { preventHandler } from '$lib/prevent-handler';
 
 /** The icon shown in the button. */
 export let icon: string;
@@ -39,15 +39,7 @@ export let title = label;
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
 
-const dispatch = createEventDispatcher<{ click: undefined }>();
-
-const onClick = () => {
-  if (disabled) {
-    return;
-  }
-
-  dispatch('click');
-};
+const handleDisabled = preventHandler(disabled);
 </script>
 
 <button
@@ -69,7 +61,8 @@ const onClick = () => {
     extraClasses
   )}
   {...$$restProps}
-  on:click={onClick}
+  on:click
+  on:click|capture={handleDisabled}
 >
   <Icon name={icon} />
 </button>

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -8,6 +8,7 @@ export { default as Collapse } from './collapse.svelte';
 export { default as Icon } from './icon/icon.svelte';
 export { default as Label, type LabelPosition } from './label.svelte';
 export { default as Pill } from './pill.svelte';
+export { preventHandler, preventKeyboardHandler } from './prevent-handler';
 export { default as Switch } from './switch.svelte';
 export { default as Radio } from './radio.svelte';
 export { default as Tabs } from './tabs.svelte';

--- a/packages/core/src/lib/input/text-input.svelte
+++ b/packages/core/src/lib/input/text-input.svelte
@@ -32,8 +32,9 @@ export let input: HTMLInputElement | undefined = undefined;
 <Input
   {...$$restProps}
   {type}
-  bind:value={value}
-  bind:input={input}
+  bind:value
+  bind:input
   on:input
   on:keydown
+  on:blur
 />

--- a/packages/core/src/lib/prevent-handler.ts
+++ b/packages/core/src/lib/prevent-handler.ts
@@ -1,0 +1,44 @@
+/**
+ * Returns an event handler that will prevent default behavior and stop
+ * immediate propagation of an event if `prevent` is true. Useful to layer
+ * disabled behavior onto native event forwarding.
+ *
+ * ```svelte
+ * export let disabled = false;
+ * const handleDisabled = preventHandler(disabled);
+ * <control on:input on:input|capture={handleDisabled} />
+ * ```
+ *
+ * @param prevent Whether or not the event should not emit
+ * @returns
+ */
+export const preventHandler = (prevent: boolean) => (event: Event) => {
+  if (prevent) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  }
+};
+
+/**
+ * Returns a keyboard event handler that will prevent default behavior and stop
+ * immediate propagation of an event if `disabled` is true. Useful to layer
+ * disabled behavior onto native keyboard event forwarding.
+ *
+ * ```svelte
+ * export let disabled = false;
+ * const handleDisabled = preventDisabled(disabled);
+ * <control on:keydown on:keydown|capture={handleDisabled} />
+ * ```
+ *
+ * @param disabled Whether or not the event should not emit
+ * @param allowedCodes A list of KeyboardEvent codes to always allow
+ * @returns
+ */
+export const preventKeyboardHandler =
+  (disabled: boolean, allowedCodes = ['Tab']) =>
+  (event: KeyboardEvent) => {
+    if (disabled && !allowedCodes.includes(event.code)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }
+  };

--- a/packages/core/src/lib/select/__tests__/select.spec.svelte
+++ b/packages/core/src/lib/select/__tests__/select.spec.svelte
@@ -22,6 +22,9 @@ export let state: SelectState = 'none';
   {disabled}
   {state}
   {...$$restProps}
+  on:change
+  on:keydown
+  on:mousedown
 >
   <option>Option 1</option>
   <option>Option 2</option>

--- a/packages/core/src/lib/select/__tests__/select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/select.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/svelte';
 import Select from '../select.svelte';
 import SelectSpec from './select.spec.svelte';
@@ -24,7 +24,7 @@ describe('Select', () => {
     const select: HTMLSelectElement =
       screen.getByPlaceholderText('Select an option');
 
-    await fireEvent.select(select, { target: { value: 'Option 2' } });
+    await fireEvent.change(select, { target: { value: 'Option 2' } });
 
     expect(select.value).toBe('Option 2');
   });
@@ -69,5 +69,121 @@ describe('Select', () => {
     expect(select).toHaveClass(
       'border-danger-dark focus:outline-danger-dark focus:outline-[1.5px] focus:-outline-offset-1'
     );
+  });
+
+  it('Emits the change event', async () => {
+    const onChange = vi.fn();
+    const { component } = render(SelectSpec, {
+      placeholder: 'Select an option',
+    });
+
+    component.$on('change', onChange);
+
+    const select: HTMLSelectElement =
+      screen.getByPlaceholderText('Select an option');
+
+    await fireEvent.change(select, { target: { value: 'Option 2' } });
+
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('Does not emit the change event when disabled', async () => {
+    const onChange = vi.fn();
+    const { component } = render(SelectSpec, {
+      placeholder: 'Select an option',
+      disabled: true,
+    });
+
+    component.$on('change', onChange);
+
+    const select: HTMLSelectElement =
+      screen.getByPlaceholderText('Select an option');
+
+    await fireEvent.change(select, { target: { value: 'Option 2' } });
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+  });
+
+  it('Emits the mousedown event', async () => {
+    const onMouseDown = vi.fn();
+    const { component } = render(SelectSpec, {
+      placeholder: 'Select an option',
+    });
+
+    component.$on('mousedown', onMouseDown);
+
+    const select: HTMLSelectElement =
+      screen.getByPlaceholderText('Select an option');
+
+    await fireEvent.mouseDown(select);
+
+    expect(onMouseDown).toHaveBeenCalledOnce();
+  });
+
+  it('Does not emit the mousedown event when disabled', async () => {
+    const onMouseDown = vi.fn();
+    const { component } = render(SelectSpec, {
+      placeholder: 'Select an option',
+      disabled: true,
+    });
+
+    component.$on('mousedown', onMouseDown);
+
+    const select: HTMLSelectElement =
+      screen.getByPlaceholderText('Select an option');
+
+    await fireEvent.mouseDown(select);
+
+    expect(onMouseDown).toHaveBeenCalledTimes(0);
+  });
+
+  it('Emits the keydown event', async () => {
+    const onKeydown = vi.fn();
+    const { component } = render(SelectSpec, {
+      placeholder: 'Select an option',
+    });
+
+    component.$on('keydown', onKeydown);
+
+    const select: HTMLSelectElement =
+      screen.getByPlaceholderText('Select an option');
+
+    await fireEvent.keyDown(select);
+
+    expect(onKeydown).toHaveBeenCalledOnce();
+  });
+
+  it('Does not emit the keydown event when disabled', async () => {
+    const onKeydown = vi.fn();
+    const { component } = render(SelectSpec, {
+      placeholder: 'Select an option',
+      disabled: true,
+    });
+
+    component.$on('keydown', onKeydown);
+
+    const select: HTMLSelectElement =
+      screen.getByPlaceholderText('Select an option');
+
+    await fireEvent.keyDown(select);
+
+    expect(onKeydown).toHaveBeenCalledTimes(0);
+  });
+
+  it('Does not emit the keydown event when disabled if code is tab', async () => {
+    const onKeydown = vi.fn();
+    const { component } = render(SelectSpec, {
+      placeholder: 'Select an option',
+      disabled: true,
+    });
+
+    component.$on('keydown', onKeydown);
+
+    const select: HTMLSelectElement =
+      screen.getByPlaceholderText('Select an option');
+
+    await fireEvent.keyDown(select, { code: 'Tab' });
+
+    expect(onKeydown).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/lib/select/select.svelte
+++ b/packages/core/src/lib/select/select.svelte
@@ -23,6 +23,7 @@ export type SelectState = 'error' | 'warn' | 'none';
 <script lang="ts">
 import cx from 'classnames';
 import { Icon } from '$lib';
+import { preventHandler, preventKeyboardHandler } from '$lib/prevent-handler';
 
 /** The selected option value, if any */
 export let value: string | undefined = undefined;
@@ -33,19 +34,8 @@ export let disabled = false;
 /** The state of the select (info, warn, error, success), if any. */
 export let state: SelectState = 'none';
 
-const handleDisabled = (event: Event) => {
-  if (disabled) {
-    event.preventDefault();
-    event.stopImmediatePropagation();
-  }
-};
-
-const handleDisabledKeydown = (event: KeyboardEvent) => {
-  if (disabled && event.code.toLowerCase() !== 'tab') {
-    event.preventDefault();
-    event.stopImmediatePropagation();
-  }
-};
+const handleDisabled = preventHandler(disabled);
+const handleDisabledKeydown = preventKeyboardHandler(disabled);
 
 $: isWarn = state === 'warn';
 $: isError = state === 'error';
@@ -70,12 +60,12 @@ $: isError = state === 'error';
       }
     )}
     {...$$restProps}
-    on:change|capture={handleDisabled}
     on:change
-    on:mousedown|capture={handleDisabled}
+    on:change|capture={handleDisabled}
     on:mousedown
-    on:keydown|capture={handleDisabledKeydown}
+    on:mousedown|capture={handleDisabled}
     on:keydown
+    on:keydown|capture={handleDisabledKeydown}
   >
     <slot />
   </select>

--- a/packages/core/src/lib/select/select.svelte
+++ b/packages/core/src/lib/select/select.svelte
@@ -23,18 +23,6 @@ export type SelectState = 'error' | 'warn' | 'none';
 <script lang="ts">
 import cx from 'classnames';
 import { Icon } from '$lib';
-import { createEventDispatcher } from 'svelte';
-
-const dispatch = createEventDispatcher<{
-  /** When the value of the select changes .*/
-  input: Event;
-
-  /** When a pointing device button (usually a mouse) is pressed on the select. */
-  mousedown: MouseEvent;
-
-  /** When a key is pressed down while the select is focused. */
-  keydown: KeyboardEvent;
-}>();
 
 /** The selected option value, if any */
 export let value: string | undefined = undefined;
@@ -45,31 +33,18 @@ export let disabled = false;
 /** The state of the select (info, warn, error, success), if any. */
 export let state: SelectState = 'none';
 
-const onInput = (event: Event) => {
+const handleDisabled = (event: Event) => {
   if (disabled) {
+    event.preventDefault();
     event.stopImmediatePropagation();
-    return;
   }
-
-  dispatch('input', event);
 };
 
-const onMouseDown = (event: MouseEvent) => {
-  if (disabled) {
+const handleDisabledKeydown = (event: KeyboardEvent) => {
+  if (disabled && event.code.toLowerCase() !== 'tab') {
+    event.preventDefault();
     event.stopImmediatePropagation();
-    return;
   }
-
-  dispatch('mousedown', event);
-};
-
-const onKeyDown = (event: KeyboardEvent) => {
-  if (disabled && event.key.toLowerCase() !== 'tab') {
-    event.stopImmediatePropagation();
-    return;
-  }
-
-  dispatch('keydown', event);
 };
 
 $: isWarn = state === 'warn';
@@ -95,11 +70,11 @@ $: isError = state === 'error';
       }
     )}
     {...$$restProps}
-    on:input={onInput}
-    on:input
-    on:mousedown={onMouseDown}
+    on:change|capture={handleDisabled}
+    on:change
+    on:mousedown|capture={handleDisabled}
     on:mousedown
-    on:keydown={onKeyDown}
+    on:keydown|capture={handleDisabledKeydown}
     on:keydown
   >
     <slot />

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -562,7 +562,7 @@ let buttonClickedTimes = 0;
 
   <div class="flex gap-4">
     <Select
-      on:input={(event) => {
+      on:change={(event) => {
         // eslint-disable-next-line no-console
         console.log('Select input', event);
       }}
@@ -663,7 +663,10 @@ let buttonClickedTimes = 0;
     <Multiselect
       options={['First Option', 'Option 2', 'C.) Option']}
       placeholder="Select an option"
-      on:input={(event) => console.log('Multiselect input', event)}
+      on:input={(event) => {
+        // eslint-disable-next-line no-console
+        console.log('Multiselect input', event);
+      }}
     />
     <Multiselect
       options={['First Option', 'Option 2', 'C.) Option']}


### PR DESCRIPTION
I noticed after bumping `prime-core` in app we had some errors popping up around the new event handling. After some experimentation the pattern I used for the `<Select />` seems to be the best way to intercept native event handling without overriding it or forcing custom events. We capture and prevent default and propagation of the event on the capture phase before letting whatever native event was passed to the component do its thing on the bubble phase. Added some tests around that as well.

Also updated the padding around the breadcrumb text to match the padding in designs. I noticed they were wider than expected when using them on the module details page in the viam app.