### PR TITLE
Reintroduce default slot behavior from legacy with proper text size

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/__tests__/banner.spec.svelte
+++ b/packages/core/src/lib/__tests__/banner.spec.svelte
@@ -26,6 +26,7 @@ export let exitable = false;
   on:close
 >
   <svelte:fragment slot="title">This is the title.</svelte:fragment>
+  <svelte:fragment slot="subtitle">This is the subtitle.</svelte:fragment>
   <svelte:fragment slot="message">This is the message.</svelte:fragment>
   <svelte:fragment slot="action">This is the action.</svelte:fragment>
 </Banner>

--- a/packages/core/src/lib/__tests__/banner.spec.ts
+++ b/packages/core/src/lib/__tests__/banner.spec.ts
@@ -3,12 +3,13 @@ import { fireEvent, render, screen } from '@testing-library/svelte';
 import Banner from './banner.spec.svelte';
 
 describe('Banner', () => {
-  it('Renders banner element with appropriate title, message, and action text', () => {
+  it('Renders banner element with appropriate title, subtitle, message, and action text', () => {
     render(Banner, {
       variant: 'info',
     });
 
     expect(screen.getByText('This is the title.')).toBeVisible();
+    expect(screen.getByText('This is the subtitle.')).toBeVisible();
     expect(screen.getByText('This is the message.')).toBeVisible();
     expect(screen.getByText('This is the action.')).toBeVisible();
   });

--- a/packages/core/src/lib/banner.svelte
+++ b/packages/core/src/lib/banner.svelte
@@ -117,11 +117,13 @@ $: {
         </figcaption>
 
         <div class="flex flex-col gap-3">
-          {#if $$slots.message}
+          {#if $$slots.subtitle}
             <p class="text-subtle-1 text-sm">
-              <slot name="message" />
+              <slot name="subtitle" />
             </p>
           {/if}
+
+          <span class="text-sm"><slot name="message" /></span>
 
           {#if $$slots.action}
             <div class="pb-2 pt-1 text-sm">

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -79,16 +79,10 @@ let buttonClickedTimes = 0;
       exitable={true}
     >
       <svelte:fragment slot="title">This is the warning title.</svelte:fragment>
+      <svelte:fragment slot="subtitle">This is the subtitle.</svelte:fragment>
 
       <svelte:fragment slot="message">
         This is <strong>the</strong> message.
-      </svelte:fragment>
-
-      <svelte:fragment slot="action">
-        <a
-          href="/"
-          class="text-link">This is the action.</a
-        >
       </svelte:fragment>
     </Banner>
 
@@ -98,6 +92,10 @@ let buttonClickedTimes = 0;
     >
       <svelte:fragment slot="title">
         This is the <em>danger</em> title.
+      </svelte:fragment>
+      <svelte:fragment slot="subtitle">This is the subtitle.</svelte:fragment>
+      <svelte:fragment slot="message">
+        This is <strong>the</strong> message.
       </svelte:fragment>
       <svelte:fragment slot="action">
         <Button variant="danger">This is the action.</Button>


### PR DESCRIPTION
Reinstating the legacy default slot as the "message" slot, and refactoring the "message" slot to the "subtitle" slot to match its style/intent:

<img width="1029" alt="Screenshot 2023-09-06 at 1 44 27 PM" src="https://github.com/viamrobotics/prime/assets/1930371/78f2b819-a4e5-40e3-b838-1a2ec747d9f0">
