### PR TITLE
APP-2206 Add rounded-none to select

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/select/select.svelte
+++ b/packages/core/src/lib/select/select.svelte
@@ -47,7 +47,7 @@ $: isError = state === 'error';
     aria-disabled={disabled ? true : undefined}
     aria-invalid={isError ? true : undefined}
     class={cx(
-      'peer h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none',
+      'peer h-[30px] w-full appearance-none rounded-none border px-2 py-1.5 text-xs leading-tight outline-none',
       {
         'border-light hover:border-gray-6 focus:border-gray-9 bg-white':
           !disabled && !isError && !isWarn,


### PR DESCRIPTION
Safari adds a `5px` border radius to selects (because of course it does.) Sharp corners for all!