### PR TITLE
Fix theme z-indexes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/theme.ts
+++ b/packages/core/theme.ts
@@ -1,9 +1,6 @@
 import type { OptionalConfig } from 'tailwindcss/types/config';
 
 export const theme = {
-  zIndex: {
-    max: '1000',
-  },
   extend: {
     fontFamily: {
       'space-grotesk':


### PR DESCRIPTION
I accidently added a `z-index` prop to the theme's root object, which obliterates all other z-index classes. It's still in `extend`.