### PR TITLE
APP-2306 Use new storybook for github pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload GitHub Pages artifacts
         uses: actions/upload-pages-artifact@v1
         with:
-          path: packages/legacy/prime
+          path: packages/storybook/prime
 
   test:
     timeout-minutes: 20

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -7,7 +7,7 @@
     "check": "pnpm run _prettier --check && pnpm run _eslint",
     "format": "pnpm run _prettier --write",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build --docs -o prime",
+    "build": "storybook build --docs -o prime",
     "_prettier": "prettier \"**/*.{js,cjs,ts,svelte,css,json,yml,yaml,md,mdx}\"",
     "_eslint": "eslint \".*.cjs\" \"**/*.{js,cjs,ts,svelte}\""
   },


### PR DESCRIPTION
This will make prime.viam.com serve the new Storybook instead. Huzzah!