### PR TITLE
Harden types for icon names

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/banner.svelte
+++ b/packages/core/src/lib/banner.svelte
@@ -10,7 +10,7 @@ export type BannerVariant = 'danger' | 'warning' | 'success' | 'info';
 <script lang="ts">
 import cx from 'classnames';
 import { createEventDispatcher } from 'svelte';
-import { Button, Icon } from '$lib';
+import { Button, Icon, type IconName } from '$lib';
 
 /** The severity of the notification you want to show users*/
 export let variant: BannerVariant;
@@ -37,7 +37,7 @@ $: isWarn = variant === 'warning';
 $: isDanger = variant === 'danger';
 $: isSuccess = variant === 'success';
 
-let icon = '';
+let icon: IconName | null = null;
 let iconClasses = '';
 $: {
   switch (variant) {
@@ -102,11 +102,13 @@ $: {
 
   <div class="relative flex w-full justify-between gap-2 p-3">
     <div class="flex gap-3">
-      <Icon
-        size="lg"
-        name={icon}
-        cx={iconClasses}
-      />
+      {#if icon}
+        <Icon
+          size="lg"
+          name={icon}
+          cx={iconClasses}
+        />
+      {/if}
 
       <figure
         class="flex flex-col"

--- a/packages/core/src/lib/button/__tests__/icon-button.spec.ts
+++ b/packages/core/src/lib/button/__tests__/icon-button.spec.ts
@@ -4,7 +4,7 @@ import { IconButton } from '$lib';
 import { cxTestArguments, cxTestResults } from '$lib/__tests__/cx-test';
 
 describe('IconButton', () => {
-  const common = { icon: 'close', label: 'close' };
+  const common = { icon: 'close' as const, label: 'close' };
   it('Renders a button in the style of the primary variant if no variant is specified', () => {
     render(IconButton, common);
     expect(screen.getByRole('button')).toHaveClass(

--- a/packages/core/src/lib/button/button.svelte
+++ b/packages/core/src/lib/button/button.svelte
@@ -11,7 +11,7 @@ For user triggered actions.
 
 <script lang="ts">
 import cx from 'classnames';
-import { Icon } from '$lib';
+import { Icon, type IconName } from '$lib';
 import { preventHandler } from '$lib/prevent-handler';
 
 /** Whether or not the button accepts clicks. */
@@ -35,7 +35,7 @@ export let title = '';
 /**
  * The icon shown in the button.
  */
-export let icon = '';
+export let icon: IconName | undefined = undefined;
 
 /** The width of the button. */
 export let width: 'full' | 'default' = 'default';

--- a/packages/core/src/lib/button/icon-button.svelte
+++ b/packages/core/src/lib/button/icon-button.svelte
@@ -11,11 +11,11 @@ For user triggered actions.
 
 <script lang="ts">
 import cx from 'classnames';
-import { Icon } from '$lib';
+import { Icon, type IconName } from '$lib';
 import { preventHandler } from '$lib/prevent-handler';
 
 /** The icon shown in the button. */
-export let icon: string;
+export let icon: IconName;
 
 /** aria-label text for accessibility */
 export let label: string;
@@ -30,7 +30,7 @@ export let type: 'button' | 'submit' | 'reset' = 'button';
 export let variant: 'primary' | 'danger' = 'primary';
 
 /**
- * The text that appears in a native popup box on hoveClassListArguements to the value
+ * The text that appears in a native popup box on hover. Defaults to the value
  * of `label`.
  */
 export let title = label;

--- a/packages/core/src/lib/context-menu/context-menu-item.svelte
+++ b/packages/core/src/lib/context-menu/context-menu-item.svelte
@@ -19,6 +19,7 @@ export type ContextMenuItemVariant = 'primary' | 'danger';
 import cx from 'classnames';
 import { createEventDispatcher } from 'svelte';
 import Icon from '$lib/icon/icon.svelte';
+import type { IconName } from '$lib/icon/icons';
 
 const dispatch = createEventDispatcher<{
   /** Fires when selected with the label */
@@ -26,10 +27,9 @@ const dispatch = createEventDispatcher<{
 }>();
 
 /**
- * Optional icon name (https://prime.viam.com/?path=/docs/elements-icon--docs).
- * No icon by default.
+ * Optional icon name shown in the item.
  */
-export let icon = '';
+export let icon: IconName | undefined = undefined;
 
 /** The style variant, default value is 'primary' */
 export let variant: ContextMenuItemVariant = 'primary';
@@ -51,7 +51,7 @@ export { extraClasses as cx };
   )}
   on:click={() => dispatch('select', { value: label })}
 >
-  {#if icon !== ''}
+  {#if icon}
     <div
       class={cx({
         'text-gray-400': variant === 'primary',

--- a/packages/core/src/lib/icon/icon.svelte
+++ b/packages/core/src/lib/icon/icon.svelte
@@ -30,10 +30,10 @@ const sizes: Record<Size, string> = {
 
 <script lang="ts">
 import cx from 'classnames';
-import { paths } from './icons';
+import { paths, type IconName } from './icons';
 
 /** The name of the icon. */
-export let name: string;
+export let name: IconName;
 
 /** The size of the icon. */
 export let size: Size = 'base';

--- a/packages/core/src/lib/icon/icons.ts
+++ b/packages/core/src/lib/icon/icons.ts
@@ -4,7 +4,7 @@ import * as MDI from '@mdi/js';
  * Keys should match MDI name
  * e.g. 'account-multiple' for MDI.mdiAccountMultiple
  */
-export const paths: Record<string, string> = {
+export const paths = {
   'account-multiple': MDI.mdiAccountMultiple,
   'alert-circle-outline': MDI.mdiAlertCircleOutline,
   'alert-circle': MDI.mdiAlertCircle,
@@ -70,3 +70,8 @@ export const paths: Record<string, string> = {
   'robot-outline': MDI.mdiRobotOutline,
   domain: MDI.mdiDomain,
 };
+
+/**
+ * The possible icon names that can be rendered. This is good for typing props.
+ */
+export type IconName = keyof typeof paths;

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -5,6 +5,7 @@ export { default as Button } from './button/button.svelte';
 export { default as IconButton } from './button/icon-button.svelte';
 export { clickOutside } from './click-outside';
 export { default as Icon } from './icon/icon.svelte';
+export type { IconName } from './icon/icons';
 export { default as Label, type LabelPosition } from './label.svelte';
 export { default as Pill } from './pill.svelte';
 export { preventHandler, preventKeyboardHandler } from './prevent-handler';

--- a/packages/core/src/lib/input/input.svelte
+++ b/packages/core/src/lib/input/input.svelte
@@ -22,6 +22,7 @@ export type InputState = 'info' | 'warn' | 'error' | 'none';
 
 <script lang="ts">
 import Icon from '$lib/icon/icon.svelte';
+import type { IconName } from '$lib/icon/icons';
 import { preventHandler, preventKeyboardHandler } from '$lib/prevent-handler';
 import cx from 'classnames';
 
@@ -50,12 +51,23 @@ $: isInputReadOnly = disabled === true || readonly === true;
 $: handleDisabled = preventHandler(isInputReadOnly);
 $: handleDisabledKeydown = preventKeyboardHandler(isInputReadOnly);
 
-$: icon = {
-  info: 'information',
-  warn: 'alert',
-  error: 'alert-circle',
-  none: '',
-}[state ?? 'none'];
+let icon: IconName | null;
+$: icon = (() => {
+  switch (state) {
+    case 'info': {
+      return 'information';
+    }
+    case 'warn': {
+      return 'alert';
+    }
+    case 'error': {
+      return 'alert-circle';
+    }
+    default: {
+      return null;
+    }
+  }
+})();
 
 $: defaultClasses =
   !disabled &&
@@ -100,7 +112,7 @@ $: errorClasses =
     on:blur
   />
 
-  {#if icon !== ''}
+  {#if icon}
     <Icon
       cx={[
         'absolute right-2 top-1.5',

--- a/packages/core/src/lib/radio.svelte
+++ b/packages/core/src/lib/radio.svelte
@@ -19,6 +19,7 @@ type LabelPosition = 'top' | 'left';
 
 import cx from 'classnames';
 import { createEventDispatcher } from 'svelte';
+import type { IconName } from './icon/icons';
 
 /**
  * The label for the radio button.
@@ -51,7 +52,7 @@ export let readonly = false;
 /**
  * The icon on the radio button.
  */
-let icon: string;
+let icon: IconName;
 /**
  * The width of the radio button.  Specifically, if width is 100% or if its the default.
  */

--- a/packages/core/src/lib/select/multiselect.svelte
+++ b/packages/core/src/lib/select/multiselect.svelte
@@ -26,6 +26,7 @@ import { selectControls } from './controls';
 import Pill from '$lib/pill.svelte';
 import { createSearchableSelectDispatcher } from './dispatcher';
 import SelectInput from './select-input.svelte';
+import type { IconName } from '$lib/icon/icons';
 
 /** The options the user should be allowed to search and select from. */
 export let options: string[] = [];
@@ -64,7 +65,7 @@ export let clearable = false;
  * An optional call-to-action button to render at the bottom of the select menu
  * that will emit the `buttonclick` event when actioned.
  */
-export let button: { text: string; icon: string } | undefined = undefined;
+export let button: { text: string; icon: IconName } | undefined = undefined;
 
 /** An optional heading to render at the top of the select menu. */
 export let heading = '';

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -22,6 +22,7 @@ import { clickOutside } from '$lib/click-outside';
 import { selectControls } from './controls';
 import { createSearchableSelectDispatcher } from './dispatcher';
 import SelectInput from './select-input.svelte';
+import type { IconName } from '$lib/icon/icons';
 
 /** The options the user should be allowed to search and select from. */
 export let options: string[] = [];
@@ -49,7 +50,7 @@ export let sort: SortOptions = 'default';
  * An optional call-to-action button to render at the bottom of the select menu
  * that will emit the `buttonclick` event when actioned.
  */
-export let button: { text: string; icon: string } | undefined = undefined;
+export let button: { text: string; icon: IconName } | undefined = undefined;
 
 /** An optional heading to render at the top of the select menu. */
 export let heading = '';

--- a/packages/core/src/lib/select/select-menu.svelte
+++ b/packages/core/src/lib/select/select-menu.svelte
@@ -5,11 +5,11 @@
 
 <script lang="ts">
 import cx from 'classnames';
-import { Icon } from '$lib';
+import { Icon, type IconName } from '$lib';
 
 export let open = false;
 export let element: HTMLUListElement;
-export let button: { text: string; icon: string } | undefined = undefined;
+export let button: { text: string; icon: IconName } | undefined = undefined;
 export let heading = '';
 
 /** Additional CSS classes to pass to the menu. */


### PR DESCRIPTION
This is a minor improvement that will hopefully improve quality of life when using icons. Icons now must be one of the available icon names instead of any `string`. Autocomplete will be more helpful and we won't ever ship code that has missing icons!

![image](https://github.com/viamrobotics/prime/assets/5910938/3e1176e2-1b6a-4c79-943f-50bc61c2b52f)
