### PR TITLE
APP-2206: break apart tooltip component for custom usage

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.40",
+  "version": "0.0.41",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -15,7 +15,14 @@ export { default as Tabs } from './tabs.svelte';
 export { default as Modal } from './modal.svelte';
 export { useUniqueId } from './unique-id';
 
-export { Tooltip, type TooltipLocation, type TooltipState } from './tooltip';
+export {
+  Tooltip,
+  TooltipContainer,
+  TooltipTarget,
+  TooltipText,
+  type TooltipLocation,
+  type TooltipVisibility,
+} from './tooltip';
 
 export { default as ContextMenu } from './context-menu/context-menu.svelte';
 export {

--- a/packages/core/src/lib/input/slider-input.svelte
+++ b/packages/core/src/lib/input/slider-input.svelte
@@ -57,7 +57,6 @@ const dispatch = createEventDispatcher<{
   change: number | undefined;
 }>();
 
-let numberDragTooltip: Tooltip;
 let numberDragCord: HTMLDivElement;
 let numberDragHead: HTMLDivElement;
 let isDragging = false;
@@ -114,13 +113,6 @@ $: handlePointerMove = (event: PointerEvent) => {
     value = next;
     dispatch('input', value);
   }
-
-  /**
-   * TODO: Determine why this is being interpreted as an `any` type by the
-   * linter when it is of `() => Promise<void>`.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  numberDragTooltip.recalculateStyle();
 };
 
 const handlePointerUp = () => {
@@ -139,13 +131,6 @@ const handlePointerDown = async (event: PointerEvent) => {
   await tick();
 
   numberDragHead.style.transform = 'translate(0px, 0px)';
-
-  /**
-   * TODO: Determine why this is being interpreted as an `any` type by the
-   * linter when it is of `() => Promise<void>`.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-  numberDragTooltip.recalculateStyle();
 };
 
 const handleInput = () => {
@@ -207,10 +192,7 @@ const handleChange = () => {
         class="pointer-events-none -ml-[2px] -mt-[5px]"
       >
         <div class="h-2 w-2">
-          <Tooltip
-            bind:this={numberDragTooltip}
-            state="visible"
-          >
+          <Tooltip state="visible">
             <div class="h-2 w-2 rounded-full bg-gray-800" />
             <span slot="description">{value}</span>
           </Tooltip>

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
@@ -5,7 +5,7 @@ import userEvent from '@testing-library/user-event';
 import Tooltip from './tooltip.spec.svelte';
 
 describe('Tooltip', () => {
-  it('Renders the target element without the tooltip', () => {
+  it('renders the target element without the tooltip', () => {
     render(Tooltip);
 
     const target = screen.getByTestId('target');
@@ -15,7 +15,17 @@ describe('Tooltip', () => {
     expect(tooltip).toHaveClass('invisible');
   });
 
-  it('Renders the tooltip when state is visible', async () => {
+  it('passes the tooltip ID to the target slot', () => {
+    render(Tooltip);
+
+    const target = screen.getByTestId('target');
+    const tooltip = screen.getByRole('tooltip');
+
+    expect(tooltip).toHaveAttribute('id', expect.any(String));
+    expect(target).toHaveAttribute('aria-describedby', tooltip.id);
+  });
+
+  it('renders the tooltip when state is visible', async () => {
     const user = userEvent.setup();
 
     render(Tooltip, { state: 'visible' });
@@ -32,7 +42,7 @@ describe('Tooltip', () => {
     expect(tooltip).not.toHaveClass('invisible');
   });
 
-  it('Renders the tooltip on mouse enter and hides it on mouse leave', async () => {
+  it('shows/hides the tooltip on mouse enter/exit', async () => {
     const user = userEvent.setup();
 
     render(Tooltip);
@@ -47,7 +57,7 @@ describe('Tooltip', () => {
     expect(tooltip).toHaveClass('invisible');
   });
 
-  it('Renders the tooltip on keyboard focus', async () => {
+  it('shows/hides the tooltip on keyboard focus/blur', async () => {
     render(Tooltip);
 
     const target = screen.getByTestId('target');

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { render, screen, waitFor } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 
 import Tooltip from './tooltip.spec.svelte';
@@ -33,7 +33,10 @@ describe('Tooltip', () => {
     const target = screen.getByTestId('target');
     const tooltip = screen.getByRole('tooltip');
 
-    expect(tooltip).not.toHaveClass('invisible');
+    // tooltip should initially be invisible before styles calculate
+    expect(tooltip).toHaveClass('invisible');
+    // then it should become visible
+    await waitFor(() => expect(tooltip).not.toHaveClass('invisible'));
 
     await user.hover(target);
     expect(tooltip).not.toHaveClass('invisible');

--- a/packages/core/src/lib/tooltip/index.ts
+++ b/packages/core/src/lib/tooltip/index.ts
@@ -1,2 +1,5 @@
 export { default as Tooltip } from './tooltip.svelte';
-export type { TooltipLocation, TooltipState } from './tooltip-styles';
+export { default as TooltipContainer } from './tooltip-container.svelte';
+export { default as TooltipTarget } from './tooltip-target.svelte';
+export { default as TooltipText } from './tooltip-text.svelte';
+export type { TooltipLocation, TooltipVisibility } from './tooltip-context';

--- a/packages/core/src/lib/tooltip/index.ts
+++ b/packages/core/src/lib/tooltip/index.ts
@@ -2,4 +2,4 @@ export { default as Tooltip } from './tooltip.svelte';
 export { default as TooltipContainer } from './tooltip-container.svelte';
 export { default as TooltipTarget } from './tooltip-target.svelte';
 export { default as TooltipText } from './tooltip-text.svelte';
-export type { TooltipLocation, TooltipVisibility } from './tooltip-context';
+export type { TooltipLocation, TooltipVisibility } from './tooltip-styles';

--- a/packages/core/src/lib/tooltip/tooltip-container.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-container.svelte
@@ -1,0 +1,40 @@
+<!--
+  @component
+
+  A wrapper component to contain a tooltip and the element it describes.
+
+  Used alongside <TooltipTarget> and <TooltipText> to create more
+  customized tooltips when the regular <Tooltip> can't be used.
+
+  For example, you may want to attach the tooltip of an input control
+  to an icon, even though the tooltip describes the input, not the icon.
+
+  ```svelte
+  <TooltipContainer let:tooltipID>
+    <Label>
+      Name
+      <TooltipTarget>
+        <Icon
+          tabindex="0"
+          cx="cursor-pointer"
+          name="information-outline"
+        />
+      </TooltipTarget>
+      <TextInput
+        slot="input"
+        aria-describedby={tooltipID}
+      />
+    </Label>
+    <TooltipText>Cool name you got there!</TooltipText>
+  </TooltipContainer>
+  ```
+-->
+<svelte:options immutable />
+
+<script lang="ts">
+import { provideTooltipStyles } from './tooltip-styles';
+
+const { id } = provideTooltipStyles();
+</script>
+
+<slot tooltipID={id} />

--- a/packages/core/src/lib/tooltip/tooltip-container.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-container.svelte
@@ -32,9 +32,9 @@
 <svelte:options immutable />
 
 <script lang="ts">
-import { provideTooltipStyles } from './tooltip-styles';
+import { provideTooltipContext } from './tooltip-styles';
 
-const { id } = provideTooltipStyles();
+const { id } = provideTooltipContext();
 </script>
 
 <slot tooltipID={id} />

--- a/packages/core/src/lib/tooltip/tooltip-styles.ts
+++ b/packages/core/src/lib/tooltip/tooltip-styles.ts
@@ -18,7 +18,7 @@ export type TooltipVisibility = 'invisible' | 'visible';
 
 export interface TooltipContext {
   id: string;
-  styles: Readable<TooltipStyles>;
+  styles: Readable<TooltipStyles | undefined>;
   isVisible: Readable<boolean>;
   setHovered: (isHovered: boolean) => void;
   setTarget: (target: HTMLElement | undefined) => void;
@@ -97,10 +97,9 @@ const createContext = (): TooltipContext => {
     state,
     ($state) => $state.visibility === 'visible' || Boolean($state.isHovered)
   );
-  const styles = derived<Readable<State>, TooltipStyles>(
+  const styles = derived<Readable<State>, TooltipStyles | undefined>(
     state,
-    updateStyles,
-    INITIAL_STYLE
+    updateStyles
   );
 
   return {

--- a/packages/core/src/lib/tooltip/tooltip-styles.ts
+++ b/packages/core/src/lib/tooltip/tooltip-styles.ts
@@ -119,9 +119,9 @@ const updateStyle = (
 };
 
 const calculateStyle = async (state: State): Promise<TooltipStyles> => {
-  const { target, tooltip, arrow, location = 'top' } = state;
+  const { target, tooltip, arrow, location } = state;
 
-  if (!target || !tooltip || !arrow) {
+  if (!target || !tooltip || !arrow || !location) {
     return INITIAL_STYLE;
   }
 

--- a/packages/core/src/lib/tooltip/tooltip-styles.ts
+++ b/packages/core/src/lib/tooltip/tooltip-styles.ts
@@ -4,7 +4,7 @@ import {
   flip,
   shift,
   offset,
-  arrow as floatingArrow,
+  arrow as arrowMiddleware,
 } from '@floating-ui/dom';
 import { setContext, getContext } from 'svelte';
 import { derived, writable, type Readable } from 'svelte/store';
@@ -134,12 +134,12 @@ const calculateStyle = async (state: State): Promise<TooltipStyles> => {
         offset(7),
         flip({ fallbackAxisSideDirection: 'start' }),
         shift({ padding: 5 }),
-        floatingArrow({ element: arrow }),
+        arrowMiddleware({ element: arrow }),
       ],
     }
   );
 
-  const { x: arrowX, y: arrowY } = middlewareData.arrow!;
+  const { x: arrowX, y: arrowY } = middlewareData.arrow ?? {};
   const side = placement.split('-')[0] as TooltipLocation;
   const staticSide = (
     { top: 'bottom', right: 'left', bottom: 'top', left: 'right' } as const

--- a/packages/core/src/lib/tooltip/tooltip-target.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-target.svelte
@@ -1,0 +1,33 @@
+<!--
+  @component
+
+  The target of a tooltip.
+
+  Used alongside <TooltipContainer> and <TooltipTarget> to create
+  customized tooltips when the regular <Tooltip> can't be used.
+
+  See <TooltipContainer> for details.
+-->
+<svelte:options immutable />
+
+<script lang="ts">
+import { useTooltipStyles } from './tooltip-styles';
+
+const { setTarget, setHovered } = useTooltipStyles();
+const hover = () => setHovered(true);
+const unhover = () => setHovered(false);
+let target: HTMLElement | undefined;
+
+$: setTarget(target);
+</script>
+
+<span
+  role="presentation"
+  bind:this={target}
+  on:mouseenter={hover}
+  on:mouseleave={unhover}
+  on:focusin={hover}
+  on:focusout={unhover}
+>
+  <slot />
+</span>

--- a/packages/core/src/lib/tooltip/tooltip-target.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-target.svelte
@@ -11,9 +11,9 @@
 <svelte:options immutable />
 
 <script lang="ts">
-import { useTooltipStyles } from './tooltip-styles';
+import { useTooltip } from './tooltip-styles';
 
-const { setTarget, setHovered } = useTooltipStyles();
+const { setTarget, setHovered } = useTooltip();
 const hover = () => setHovered(true);
 const unhover = () => setHovered(false);
 let target: HTMLElement | undefined;

--- a/packages/core/src/lib/tooltip/tooltip-text.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-text.svelte
@@ -32,17 +32,17 @@ $: setTooltip({ tooltip, arrow, location, visibility: state });
   {id}
   role="tooltip"
   class="absolute left-0 top-0 z-max w-max max-w-[250px] border border-gray-9"
-  class:invisible={!$isVisible}
-  style:top={$styles.tooltip.top}
-  style:left={$styles.tooltip.left}
+  class:invisible={!$isVisible || !$styles}
+  style:top={$styles?.tooltip.top}
+  style:left={$styles?.tooltip.left}
 >
   <div
     bind:this={arrow}
     class="absolute h-[8.5px] w-[8.5px] rotate-45 bg-gray-9"
-    style:top={$styles.arrow.top}
-    style:left={$styles.arrow.left}
-    style:right={$styles.arrow.right}
-    style:bottom={$styles.arrow.bottom}
+    style:top={$styles?.arrow.top}
+    style:left={$styles?.arrow.left}
+    style:right={$styles?.arrow.right}
+    style:bottom={$styles?.arrow.bottom}
   />
 
   <div

--- a/packages/core/src/lib/tooltip/tooltip-text.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-text.svelte
@@ -1,0 +1,54 @@
+<!--
+  @component
+
+  The text of a tooltip.
+
+  Used alongside <TooltipContainer> and <TooltipTarget> to create
+  customized tooltips when the regular <Tooltip> can't be used.
+
+  See <TooltipContainer> for details.
+-->
+<svelte:options immutable />
+
+<script lang="ts">
+import {
+  useTooltipStyles,
+  type TooltipLocation,
+  type TooltipVisibility,
+} from './tooltip-styles';
+
+export let location: TooltipLocation = 'top';
+export let visibility: TooltipVisibility = 'invisible';
+
+const styles = useTooltipStyles();
+const { id, setTooltip } = styles;
+let tooltip: HTMLElement | undefined;
+let arrow: HTMLElement | undefined;
+
+$: setTooltip(location, visibility, tooltip, arrow);
+</script>
+
+<div
+  bind:this={tooltip}
+  {id}
+  role="tooltip"
+  class="invisible absolute left-0 top-0 z-max w-max max-w-[250px] border border-gray-9"
+  style:visibility={$styles.tooltip.visibility}
+  style:top={$styles.tooltip.top}
+  style:left={$styles.tooltip.left}
+>
+  <div
+    bind:this={arrow}
+    class="absolute h-[8.5px] w-[8.5px] rotate-45 bg-gray-9"
+    style:top={$styles.arrow.top}
+    style:left={$styles.arrow.left}
+    style:right={$styles.arrow.right}
+    style:bottom={$styles.arrow.bottom}
+  />
+
+  <div
+    class="flex items-center gap-1 bg-gray-9 px-2 py-1 text-left text-xs text-white"
+  >
+    <slot />
+  </div>
+</div>

--- a/packages/core/src/lib/tooltip/tooltip-text.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-text.svelte
@@ -12,28 +12,27 @@
 
 <script lang="ts">
 import {
-  useTooltipStyles,
+  useTooltip,
   type TooltipLocation,
   type TooltipVisibility,
 } from './tooltip-styles';
 
 export let location: TooltipLocation = 'top';
-export let visibility: TooltipVisibility = 'invisible';
+export let state: TooltipVisibility = 'invisible';
 
-const styles = useTooltipStyles();
-const { id, setTooltip } = styles;
+const { id, styles, isVisible, setTooltip } = useTooltip();
 let tooltip: HTMLElement | undefined;
 let arrow: HTMLElement | undefined;
 
-$: setTooltip(location, visibility, tooltip, arrow);
+$: setTooltip({ tooltip, arrow, location, visibility: state });
 </script>
 
 <div
   bind:this={tooltip}
   {id}
   role="tooltip"
-  class="invisible absolute left-0 top-0 z-max w-max max-w-[250px] border border-gray-9"
-  style:visibility={$styles.tooltip.visibility}
+  class="absolute left-0 top-0 z-max w-max max-w-[250px] border border-gray-9"
+  class:invisible={!$isVisible}
   style:top={$styles.tooltip.top}
   style:left={$styles.tooltip.left}
 >

--- a/packages/core/src/lib/tooltip/tooltip.svelte
+++ b/packages/core/src/lib/tooltip/tooltip.svelte
@@ -17,12 +17,9 @@
 <svelte:options immutable />
 
 <script lang="ts">
-import {
-  provideTooltipStyles,
-  type TooltipLocation,
-  type TooltipVisibility,
-} from './tooltip-styles';
+import type { TooltipLocation, TooltipVisibility } from './tooltip-styles';
 
+import TooltipContainer from './tooltip-container.svelte';
 import TooltipTarget from './tooltip-target.svelte';
 import TooltipText from './tooltip-text.svelte';
 
@@ -37,16 +34,16 @@ export let location: TooltipLocation = 'top';
  * will only render on mouse enter and focus
  */
 export let state: TooltipVisibility = 'invisible';
-
-const { id } = provideTooltipStyles();
 </script>
 
-<TooltipTarget>
-  <slot tooltipID={id} />
-</TooltipTarget>
-<TooltipText
-  {location}
-  visibility={state}
->
-  <slot name="description" />
-</TooltipText>
+<TooltipContainer let:tooltipID>
+  <TooltipTarget>
+    <slot {tooltipID} />
+  </TooltipTarget>
+  <TooltipText
+    {location}
+    {state}
+  >
+    <slot name="description" />
+  </TooltipText>
+</TooltipContainer>

--- a/packages/core/src/lib/tooltip/tooltip.svelte
+++ b/packages/core/src/lib/tooltip/tooltip.svelte
@@ -14,18 +14,17 @@
   </Tooltip>
   ```
 -->
-<svelte:options
-  immutable
-  accessors
-/>
+<svelte:options immutable />
 
 <script lang="ts">
-import { useUniqueId } from '$lib/unique-id';
 import {
-  tooltipStyles,
+  provideTooltipStyles,
   type TooltipLocation,
-  type TooltipState,
+  type TooltipVisibility,
 } from './tooltip-styles';
+
+import TooltipTarget from './tooltip-target.svelte';
+import TooltipText from './tooltip-text.svelte';
 
 /**
  * The desired location for the tooltip, may be computed to a different
@@ -37,61 +36,17 @@ export let location: TooltipLocation = 'top';
  * If `visible`, the tooltip will always render. When `invisible` the tooltip
  * will only render on mouse enter and focus
  */
-export let state: TooltipState = 'invisible';
+export let state: TooltipVisibility = 'invisible';
 
-const tooltipID = useUniqueId('tooltip');
-let target: HTMLElement | undefined;
-let tooltip: HTMLElement | undefined;
-let arrow: HTMLElement | undefined;
-let isHovered = false;
-let isVisible = false;
-
-const styles = tooltipStyles();
-const show = () => (isHovered = true);
-const hide = () => (isHovered = false);
-
-$: {
-  isVisible = state === 'visible' || isHovered;
-  styles.recalculate(target, tooltip, arrow, location);
-}
-
-export const recalculateStyle = () => {
-  styles.recalculate(target, tooltip, arrow, location);
-};
+const { id } = provideTooltipStyles();
 </script>
 
-<span
-  role="presentation"
-  bind:this={target}
-  on:mouseenter={show}
-  on:mouseleave={hide}
-  on:focusin={show}
-  on:focusout={hide}
+<TooltipTarget>
+  <slot tooltipID={id} />
+</TooltipTarget>
+<TooltipText
+  {location}
+  visibility={state}
 >
-  <slot {tooltipID} />
-</span>
-
-<div
-  bind:this={tooltip}
-  id={tooltipID}
-  role="tooltip"
-  class:invisible={!isVisible}
-  class="absolute left-0 top-0 z-max w-max max-w-[250px] border border-gray-9"
-  style:top={$styles.tooltip.top}
-  style:left={$styles.tooltip.left}
->
-  <div
-    bind:this={arrow}
-    class="absolute h-[8.5px] w-[8.5px] rotate-45 bg-gray-9"
-    style:top={$styles.arrow.top}
-    style:left={$styles.arrow.left}
-    style:right={$styles.arrow.right}
-    style:bottom={$styles.arrow.bottom}
-  />
-
-  <div
-    class="flex items-center gap-1 bg-gray-9 px-2 py-1 text-left text-xs text-white"
-  >
-    <slot name="description" />
-  </div>
-</div>
+  <slot name="description" />
+</TooltipText>

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -16,6 +16,9 @@ import {
   Radio,
   Tabs,
   Tooltip,
+  TooltipContainer,
+  TooltipTarget,
+  TooltipText,
   TextInput,
   NumericInput,
   SliderInput,
@@ -874,19 +877,25 @@ const notify = useNotify();
       <p slot="description">This is the tooltip text!</p>
     </Tooltip>
 
-    <Tooltip
-      let:tooltipID
-      location="bottom"
-    >
-      <p
-        aria-describedby={tooltipID}
-        class="flex items-center gap-1"
-      >
-        This element has a bottom tooltip and an icon!
-        <Icon name="information-outline" />
-      </p>
-      <p slot="description">This is the tooltip text!</p>
-    </Tooltip>
+    <div>
+      <TooltipContainer let:tooltipID>
+        <Label>
+          This element has a bottom tooltip on an icon!
+          <TooltipTarget>
+            <Icon
+              tabindex="0"
+              cx="cursor-pointer"
+              name="information-outline"
+            />
+          </TooltipTarget>
+          <TextInput
+            slot="input"
+            aria-describedby={tooltipID}
+          />
+        </Label>
+        <TooltipText location="bottom">This is the tooltip text!</TooltipText>
+      </TooltipContainer>
+    </div>
   </div>
 
   <!-- Vector Input -->

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -877,6 +877,17 @@ const notify = useNotify();
       <p slot="description">This is the tooltip text!</p>
     </Tooltip>
 
+    <Tooltip
+      let:tooltipID
+      location="bottom"
+      state="visible"
+    >
+      <p aria-describedby={tooltipID}>
+        This element has visible bottom tooltip.
+      </p>
+      <p slot="description">This is the tooltip text!</p>
+    </Tooltip>
+
     <div>
       <TooltipContainer let:tooltipID>
         <Label>
@@ -893,7 +904,7 @@ const notify = useNotify();
             aria-describedby={tooltipID}
           />
         </Label>
-        <TooltipText location="bottom">This is the tooltip text!</TooltipText>
+        <TooltipText>This is the tooltip text!</TooltipText>
       </TooltipContainer>
     </div>
   </div>

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -891,7 +891,7 @@ const notify = useNotify();
     <div>
       <TooltipContainer let:tooltipID>
         <Label>
-          This element has a bottom tooltip on an icon!
+          This element has a tooltip on an icon!
           <TooltipTarget>
             <Icon
               tabindex="0"

--- a/packages/storybook/src/stories/tooltip.mdx
+++ b/packages/storybook/src/stories/tooltip.mdx
@@ -19,6 +19,10 @@ import { Tooltip } from '@viamrobotics/prime-core';
   <Story of={TooltipStories.RichHTML} />
 </Canvas>
 
+<Canvas>
+  <Story of={TooltipStories.CustomTarget} />
+</Canvas>
+
 {/* TODO (APP-2290): Add this when Icon is added */}
 {/* <Canvas> */}
 {/* <Story name='With Icon'> */}

--- a/packages/storybook/src/stories/tooltip.stories.svelte
+++ b/packages/storybook/src/stories/tooltip.stories.svelte
@@ -1,30 +1,58 @@
 <script lang="ts">
 import { Meta, Story } from '@storybook/addon-svelte-csf';
-import { Tooltip, Icon } from '@viamrobotics/prime-core';
+import {
+  Tooltip,
+  TooltipContainer,
+  TooltipTarget,
+  TooltipText,
+  Icon,
+} from '@viamrobotics/prime-core';
 </script>
 
 <Meta title="Elements/Tooltip" />
 
 <Story name="Plain Text">
-  <div class="pt-5">
+  <div class="flex pt-5">
     <Tooltip let:tooltipID>
       <p aria-describedby={tooltipID}>This element has a tooltip.</p>
-      <Icon name="information-outline" />
       <p slot="description">This is the tooltip text!</p>
     </Tooltip>
   </div>
 </Story>
 
 <Story name="Rich HTML">
-  <div class="pt-5">
+  <div class="flex pt-5">
     <Tooltip let:tooltipID>
       <p aria-describedby={tooltipID}>
         This <b>element</b> has a <em>tooltip</em>.
       </p>
-      <Icon name="information-outline" />
       <p slot="description">
         This is the <b class="underline">tooltip text!</b>
       </p>
     </Tooltip>
+  </div>
+</Story>
+
+<Story name="Custom Target">
+  <div class="flex">
+    <TooltipContainer let:tooltipID>
+      <p
+        aria-describedby={tooltipID}
+        class="flex items-center gap-1"
+      >
+        This element has a tooltip on the icon.
+        <TooltipTarget>
+          <Icon
+            name="information-outline"
+            label="information"
+            cx="cursor-pointer"
+          />
+        </TooltipTarget>
+      </p>
+
+      <TooltipText location="right">
+        This is the <b class="underline">tooltip text!</b>
+      </TooltipText>
+    </TooltipContainer>
   </div>
 </Story>

--- a/packages/storybook/src/stories/tooltip.stories.svelte
+++ b/packages/storybook/src/stories/tooltip.stories.svelte
@@ -50,9 +50,7 @@ import {
         </TooltipTarget>
       </p>
 
-      <TooltipText location="right">
-        This is the <b class="underline">tooltip text!</b>
-      </TooltipText>
+      <TooltipText location="right">This is the tooltip text!</TooltipText>
     </TooltipContainer>
   </div>
 </Story>


### PR DESCRIPTION
## Overview

Following up on #381, as I went to integrate the updated Tooltip, I saw that several Svelte usage sites of this tooltip would benefit from the "separate target from described element" work I mentioned in that ticket.

This PR breaks the `<Tooltip>` into its constituent parts:

- `<TooltipContainer>` - a stateful wrapper
- `<TooltipTarget>` - a wrapper that attaches mouse/focus event listeners
- `<TooltipText>` - a presentational tooltip text component
 
You can continue to use `<Tooltip>`, or if that doesn't work for the UI in question, assemble the three parts however you need. In practice, I think this will mostly be "the visual target is different that the element on which we need to set `aria-describedby`.

I also upgraded the style calculation logic to automatically adjust scrolls/resizes/moves via floating-ui's [`autoUpdate`](https://floating-ui.com/docs/autoUpdate).

![2023-09-25 14 30 13](https://github.com/viamrobotics/prime/assets/2963448/ad57f6a7-6f59-4da4-9f36-76fc26bd371c)

## Change log

- Add `TooltipContainer`, `TooltipTarget`, and `TooltipText` components that can be composed to create custom tooltips
- Wire in `autoUpdate` so the `recalculateStyle` component export isn't needed

## Review requests

I have updated the playground and the Storybook, which are good places to start with this PR. The actual positioning logic is hard to test without Playwright, but if you do see anything that could use unit testing that isn't currently tested, please call it out!

The best way to test the `autoUpdate` functionality:

- Test the `<SliderInput>`
- Scroll up and down on the dev playground, where I've added a permanently visible tooltip