### PR TITLE
Remove extra flex from label

### DIFF
--- a/packages/core/src/lib/label.svelte
+++ b/packages/core/src/lib/label.svelte
@@ -50,7 +50,7 @@ export { extraClasses as cx };
   )}
 >
   <span
-    class={cx('flex text-xs', {
+    class={cx('text-xs', {
       'inline whitespace-nowrap': position === 'left',
       'text-subtle-1': !disabled,
       'cursor-not-allowed text-disabled-dark': disabled,

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -492,6 +492,13 @@ const notify = useNotify();
       />
     </Label>
   </div>
+  <Label position="left">
+    Left
+    <Input
+      slot="input"
+      name="name"
+    />
+  </Label>
 
   <!-- Notify -->
   <h1 class="text-2xl">Notify</h1>


### PR DESCRIPTION
I think this flex is causing issues with the label positioning -- it's causing the label to be on the left even with position has value `top`