### PR TITLE
Vector input fixes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.39",
+  "version": "0.0.40",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/__tests__/vector-input.spec.ts
+++ b/packages/core/src/lib/__tests__/vector-input.spec.ts
@@ -73,10 +73,10 @@ describe('VectorInput', () => {
     const onInput = vi.fn();
     component.$on('input', onInput);
 
-    const [slider] = screen.getAllByRole('button', { hidden: true, });
+    const [slider] = screen.getAllByRole('button', { hidden: true });
 
     if (!slider) {
-      throw new Error('No slider found!')
+      throw new Error('No slider found!');
     }
 
     await fireEvent.pointerDown(slider, { clientX: 0 });
@@ -92,15 +92,14 @@ describe('VectorInput', () => {
 
   it('Emits the input and change events when the input is changed', async () => {
     const { component } = render(VectorInput, {
-      placeholders: { x: '0', y: '1', z: '2' }
+      placeholders: { x: '0', y: '1', z: '2' },
     });
 
     const onChange = vi.fn();
 
     component.$on('change', onChange);
 
-    const input: HTMLInputElement =
-      screen.getByPlaceholderText('0');
+    const input: HTMLInputElement = screen.getByPlaceholderText('0');
 
     await fireEvent.change(input, { target: { value: 20 } });
 

--- a/packages/core/src/lib/vector-input.svelte
+++ b/packages/core/src/lib/vector-input.svelte
@@ -13,8 +13,6 @@ For numeric user inputs that require easy adjustment.
   />
 ```
 -->
-<svelte:options immutable />
-
 <script lang="ts">
 import { createEventDispatcher } from 'svelte';
 import cx from 'classnames';
@@ -45,6 +43,9 @@ export { extraClasses as cx };
 const dispatch = createEventDispatcher<{
   /** Fires when an input event occurs. */
   input: Record<string, number>;
+
+  /** Fires when an input value changes. */
+  change: Record<string, number>;
 }>();
 
 const inputs: Record<string, HTMLInputElement> = {};
@@ -57,9 +58,11 @@ const handleInput = (label: string) => {
   }
 };
 
-const handleKeydown = (event: KeyboardEvent, label: string) => {
-  if (event.key === 'Enter') {
-    handleInput(label);
+const handleChange = (label: string) => {
+  const value = inputs[label]?.valueAsNumber;
+  if (value !== undefined && !Number.isNaN(value)) {
+    values[label] = value;
+    dispatch('change', values);
   }
 };
 </script>
@@ -77,9 +80,8 @@ const handleKeydown = (event: KeyboardEvent, label: string) => {
         placeholder={placeholders[label]}
         value={values[label]}
         incrementor={readonly ? '' : 'slider'}
-        on:blur={() => handleInput(label)}
         on:input={() => handleInput(label)}
-        on:keydown={(event) => handleKeydown(event, label)}
+        on:change={() => handleChange(label)}
       />
     </Label>
   {/each}

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -896,25 +896,27 @@ const notify = useNotify();
       // eslint-disable-next-line no-console
       console.log('VectorInput input', event);
     }}
+    on:change={(event) => {
+      // eslint-disable-next-line no-console
+      console.log('VectorInput change', event);
+    }}
   />
 
   <VectorInput
     type="number"
     step={10}
-    labels={['x', 'y', 'z', 'd']}
+    labels={['x', 'y', 'z', 'w']}
     placeholders={{
       x: '0',
       y: '0',
       z: '0',
-      // eslint-disable-next-line id-length
-      d: '0',
+      w: '0',
     }}
     values={{
       x: 0,
       y: 0,
       z: 0,
-      // eslint-disable-next-line id-length
-      d: 0,
+      w: 0,
     }}
     on:input={(event) => {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
Fixes a few minor issues with vector input that emerged due to recent changes:
* Vector input cannot be set as an immutable component, because it depends on object props that in some cases must be mutable
* Vector input should fire `input` and `change` events like the underlying `SliderInput` that it wraps.