### PR TITLE
Rename useUniqueId -> uniqueId

### DIFF
--- a/packages/core/src/lib/__tests__/unique-id.spec.ts
+++ b/packages/core/src/lib/__tests__/unique-id.spec.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { useUniqueId } from '$lib';
+import { uniqueId } from '$lib';
 
-describe('useUniqueId', () => {
+describe('uniqueId', () => {
   it('should return a unique ID with the default prefix', () => {
-    const first = useUniqueId();
-    const second = useUniqueId();
-    const third = useUniqueId();
+    const first = uniqueId();
+    const second = uniqueId();
+    const third = uniqueId();
 
     expect(first.includes('uid_')).toBeTruthy();
     expect(second.includes('uid_')).toBeTruthy();
@@ -15,9 +15,9 @@ describe('useUniqueId', () => {
   });
 
   it('should return a unique ID with the passed prefix', () => {
-    const first = useUniqueId('test');
-    const second = useUniqueId('test');
-    const third = useUniqueId('test');
+    const first = uniqueId('test');
+    const second = uniqueId('test');
+    const third = uniqueId('test');
 
     expect(first.includes('test_')).toBeTruthy();
     expect(second.includes('test_')).toBeTruthy();

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -13,7 +13,7 @@ export { default as Switch } from './switch.svelte';
 export { default as Radio } from './radio.svelte';
 export { default as Tabs } from './tabs.svelte';
 export { default as Modal } from './modal.svelte';
-export { useUniqueId } from './unique-id';
+export { uniqueId } from './unique-id';
 
 export { Tooltip, type TooltipLocation, type TooltipState } from './tooltip';
 

--- a/packages/core/src/lib/notification/context.ts
+++ b/packages/core/src/lib/notification/context.ts
@@ -7,7 +7,7 @@ import {
   type Writable,
 } from 'svelte/store';
 
-import { useUniqueId } from '$lib/unique-id';
+import { uniqueId } from '$lib/unique-id';
 import { BannerVariant, type BannerVariantType } from '$lib/banner';
 
 import { pausableProgress } from './pausable-progress';
@@ -61,7 +61,7 @@ export const createNotifyContext = (): NotifyContext => {
   const add =
     (variant: BannerVariantType) =>
     (title: string, message?: string): void => {
-      const id = useUniqueId('notification');
+      const id = uniqueId('notification');
       const isPaused = derived(
         [pageIsVisible, pausedID],
         ([$pageIsVisible, $pausedID]) => $pausedID === id || !$pageIsVisible

--- a/packages/core/src/lib/select/multiselect.svelte
+++ b/packages/core/src/lib/select/multiselect.svelte
@@ -16,7 +16,7 @@ For selecting multiple options from a list.
 import cx from 'classnames';
 
 import { clickOutside } from '$lib/click-outside';
-import { useUniqueId } from '$lib/unique-id';
+import { uniqueId } from '$lib/unique-id';
 
 import SelectMenu from './select-menu.svelte';
 import type { SelectState } from './select.svelte';
@@ -85,7 +85,7 @@ const dispatch = createSearchableSelectDispatcher<{
   clear: null;
 }>();
 
-const menuId = useUniqueId('multiselect');
+const menuId = uniqueId('multiselect');
 
 let menu: HTMLUListElement;
 

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -17,7 +17,7 @@ import cx from 'classnames';
 import SelectMenu from './select-menu.svelte';
 import type { SelectState } from './select.svelte';
 import { type SortOptions, getSearchResults } from './search';
-import { useUniqueId } from '$lib/unique-id';
+import { uniqueId } from '$lib/unique-id';
 import { clickOutside } from '$lib/click-outside';
 import { selectControls } from './controls';
 import { createSearchableSelectDispatcher } from './dispatcher';
@@ -64,7 +64,7 @@ const dispatch = createSearchableSelectDispatcher<{
   input: string | undefined;
 }>();
 
-const menuId = useUniqueId('searchable-select');
+const menuId = uniqueId('searchable-select');
 
 let menu: HTMLUListElement;
 

--- a/packages/core/src/lib/tooltip/tooltip.svelte
+++ b/packages/core/src/lib/tooltip/tooltip.svelte
@@ -20,7 +20,7 @@
 />
 
 <script lang="ts">
-import { useUniqueId } from '$lib/unique-id';
+import { uniqueId } from '$lib/unique-id';
 import {
   tooltipStyles,
   type TooltipLocation,
@@ -39,7 +39,7 @@ export let location: TooltipLocation = 'top';
  */
 export let state: TooltipState = 'invisible';
 
-const tooltipID = useUniqueId('tooltip');
+const tooltipID = uniqueId('tooltip');
 let target: HTMLElement | undefined;
 let tooltip: HTMLElement | undefined;
 let arrow: HTMLElement | undefined;

--- a/packages/core/src/lib/unique-id.ts
+++ b/packages/core/src/lib/unique-id.ts
@@ -5,11 +5,11 @@ import { nanoid } from 'nanoid/non-secure';
  *
  * ```ts
  * // some-component.svelte
- * import { useUniqueId } from './unique-id';
+ * import { uniqueId } from './unique-id';
  * const myId = uniqueId(); // returns 'uid_XXXXX`
  * const myOtherId = uniqueId('other'); // returns 'other_XXXXX`
  * ```
  */
-export const useUniqueId = (prefix = 'uid'): string => {
+export const uniqueId = (prefix = 'uid'): string => {
   return `${prefix}_${nanoid()}`;
 };

--- a/packages/storybook/src/stories/unique-id.mdx
+++ b/packages/storybook/src/stories/unique-id.mdx
@@ -1,0 +1,22 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import * as UniqueIdStories from './unique-id.stories.svelte';
+
+<Meta title='APIs/uniqueId' />
+
+# uniqueId
+
+An API for unique IDs with an optional prefix.
+
+## Usage
+
+To create a unique ID, use the `uniqueId` function:
+
+```ts
+import { uniqueId } from '@viamrobotics/prime-core';
+
+const id = uniqueId('my-prefix');
+```
+
+<Canvas>
+  <Story of={UniqueIdStories.Example} />
+</Canvas>

--- a/packages/storybook/src/stories/unique-id.stories.svelte
+++ b/packages/storybook/src/stories/unique-id.stories.svelte
@@ -17,7 +17,7 @@ const third = uniqueId('fake');
     <div
       id={club}
       title={club}
-      class="w-40 h-80 flex items-center justify-center bg-slate-700 text-white"
+      class="flex h-80 w-40 items-center justify-center bg-slate-700 text-white"
     >
       Club PRIME
     </div>
@@ -25,35 +25,35 @@ const third = uniqueId('fake');
     <div
       id={door}
       title={door}
-      class="w-4 h-20 bg-red-900"
+      class="h-20 w-4 bg-red-900"
     />
 
     <div class="flex flex-col gap-2">
       <div
         id={bouncer}
         title={bouncer}
-        class="w-20 h-20 bg-black text-white flex items-center justify-center"
+        class="flex h-20 w-20 items-center justify-center bg-black text-white"
       >
         Bouncer
       </div>
       <div
         id={first}
         title={first}
-        class="w-20 h-20 bg-red-300 flex items-center justify-center"
+        class="flex h-20 w-20 items-center justify-center bg-red-300"
       >
         Patron
       </div>
       <div
         id={second}
         title={second}
-        class="w-20 h-20 bg-blue-300 flex items-center justify-center"
+        class="flex h-20 w-20 items-center justify-center bg-blue-300"
       >
         Patron
       </div>
       <div
         id={third}
         title={third}
-        class="w-20 h-20 bg-yellow-300 flex items-center justify-center"
+        class="flex h-20 w-20 items-center justify-center bg-yellow-300"
       >
         Patron
       </div>

--- a/packages/storybook/src/stories/unique-id.stories.svelte
+++ b/packages/storybook/src/stories/unique-id.stories.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+import { Meta, Story } from '@storybook/addon-svelte-csf';
+import { uniqueId } from '@viamrobotics/prime-core';
+
+const club = uniqueId();
+const door = uniqueId();
+const bouncer = uniqueId();
+const first = uniqueId();
+const second = uniqueId('real');
+const third = uniqueId('fake');
+</script>
+
+<Meta title="APIs/uniqueId" />
+
+<Story name="Example">
+  <div class="flex gap-0.5">
+    <div
+      id={club}
+      title={club}
+      class="w-40 h-80 flex items-center justify-center bg-slate-700 text-white"
+    >
+      Club PRIME
+    </div>
+
+    <div
+      id={door}
+      title={door}
+      class="w-4 h-20 bg-red-900"
+    />
+
+    <div class="flex flex-col gap-2">
+      <div
+        id={bouncer}
+        title={bouncer}
+        class="w-20 h-20 bg-black text-white flex items-center justify-center"
+      >
+        Bouncer
+      </div>
+      <div
+        id={first}
+        title={first}
+        class="w-20 h-20 bg-red-300 flex items-center justify-center"
+      >
+        Patron
+      </div>
+      <div
+        id={second}
+        title={second}
+        class="w-20 h-20 bg-blue-300 flex items-center justify-center"
+      >
+        Patron
+      </div>
+      <div
+        id={third}
+        title={third}
+        class="w-20 h-20 bg-yellow-300 flex items-center justify-center"
+      >
+        Patron
+      </div>
+    </div>
+  </div>
+</Story>


### PR DESCRIPTION
More changes from https://github.com/viamrobotics/prime/pull/357 This one renames `useUniqueId` to `uniqueId` because it is _not_ a hook, and adds a storybook story for `uniqueId`.
