### PR TITLE
Add h-7.5 and w-7.5 classes

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -80,3 +80,91 @@ pnpm -C packages/core test:watch  # watch tests
 ```
 
 [vitest]: https://vitest.dev/
+
+## Anatomy of a Component
+
+For easier readability, we try to use a standard ordering for component composition. These are not strict rules, but more a guideline to follow. Implementation specifics may force you to go outside this guideline.
+
+```html
+<!-- svelte options: https://svelte.dev/docs/special-elements#svelte-options -->
+<svelte:options immutable />
+
+<script
+  lang="ts"
+  context="module"
+>
+  // exported types
+  export type MyType = 'thing' | 'other-thing';
+</script>
+
+<script lang="ts">
+  // external imports
+  import { onMount, createEventDispatcher } from 'svelte';
+
+  // internal imports
+  import { someLibraryFunction } from '$lib';
+  import { someSiblingFunction } from './sibling';
+
+  // prop declarations
+  /** A doc string for prop explaining what it does. */
+  export let prop: MyType | undefined = undefined;
+
+  // event dispatchers and other hooks
+  const dispatcher = createEventDispatcher<{
+    /** A doc string for the event handler. */
+    click: null; // void event
+    /** A doc string for the event handler. */
+    primitive: string | number | boolean; // simple primitive values
+    /** A doc string for the event handler. */
+    object: { id: string; next: number; }; // complex values
+    /** A doc string for the event handler. */
+    native: Event // native events (for pure atoms)
+  }>()
+
+  // internal fields
+  let someString = '';
+
+  // reactive variables
+  $: isThing = prop === 'thing';
+
+  // complex reactive variables
+  let counter = 0;
+  $: if (isThing) {
+      counter = someString.length;
+      if (counter > 10) {
+        counter = 10;
+      }
+  }
+
+  // single-line functions
+  const doSomething = () => someLibraryFunction();
+
+  // multi-line functions
+  const doSomethingElse = () => {
+    const shouldDoSomething = someString !== '';
+    someSiblingFunction(shouldDoSomething);
+  }
+
+  // reactive statements
+  $: {
+    someString = prop ? 'whoa' : 'no';
+  }
+
+  // lifecycle hooks
+  onMount(() => ...);
+</script>
+
+<!-- Your layout -->
+<div class="border-black">
+  <!-- 
+    all slots should be named if there are multiple; otherwise a single slot 
+    can be the default `<slot />`  
+  -->
+  <slot name="title" />
+  <slot name="content" />
+</div>
+
+<style>
+  /* custom styles */
+</style>
+```

--- a/packages/core/src/lib/button/icon-button.svelte
+++ b/packages/core/src/lib/button/icon-button.svelte
@@ -48,7 +48,7 @@ $: handleDisabled = preventHandler(disabled);
   aria-disabled={disabled ? true : undefined}
   {title}
   class={cx(
-    'inline-flex h-[30px] w-[30px] select-none items-center justify-center whitespace-nowrap',
+    'inline-flex h-7.5 w-7.5 select-none items-center justify-center whitespace-nowrap',
     {
       'text-gray-6 hover:border-medium hover:bg-medium active:bg-gray-2':
         !disabled,

--- a/packages/core/src/lib/input/__tests__/input.spec.ts
+++ b/packages/core/src/lib/input/__tests__/input.spec.ts
@@ -10,7 +10,7 @@ describe('Input', () => {
     const input = screen.getByPlaceholderText('Enter your name');
 
     expect(input).toHaveClass(
-      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+      'h-7.5 w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
     );
 
     expect(input).not.toHaveClass(
@@ -24,7 +24,7 @@ describe('Input', () => {
     const input = screen.getByPlaceholderText('Enter your name');
 
     expect(input).toHaveClass(
-      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+      'h-7.5 w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
     );
 
     expect(input).toHaveClass(
@@ -40,7 +40,7 @@ describe('Input', () => {
     const input = screen.getByPlaceholderText('Enter your name');
 
     expect(input).toHaveClass(
-      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+      'h-7.5 w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
     );
 
     expect(input).toHaveClass('bg-light border-transparent');

--- a/packages/core/src/lib/input/input.svelte
+++ b/packages/core/src/lib/input/input.svelte
@@ -94,7 +94,7 @@ $: errorClasses =
     aria-disabled={disabled ? true : undefined}
     aria-invalid={isError ? true : undefined}
     class={cx(
-      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none',
+      'h-7.5 w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none',
       defaultClasses,
       readonlyClasses,
       disabledClasses,

--- a/packages/core/src/lib/select/__tests__/multiselect.spec.ts
+++ b/packages/core/src/lib/select/__tests__/multiselect.spec.ts
@@ -20,7 +20,7 @@ describe('Multiselect', () => {
     const select = screen.getByPlaceholderText('Select an option');
 
     expect(select).toHaveClass(
-      'h-[30px] w-full grow appearance-none border py-1.5 pl-2 pr-1 text-xs leading-tight outline-none'
+      'h-7.5 w-full grow appearance-none border py-1.5 pl-2 pr-1 text-xs leading-tight outline-none'
     );
   });
 
@@ -88,7 +88,7 @@ describe('Multiselect', () => {
 
     expect(button).toHaveClass('pl-1.5');
     expect(button.parentElement).toHaveClass(
-      'hover:bg-light border-light flex h-[30px] w-full items-center border-t px-2 py-1 text-xs'
+      'hover:bg-light border-light flex h-7.5 w-full items-center border-t px-2 py-1 text-xs'
     );
   });
 

--- a/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
@@ -20,7 +20,7 @@ describe('SearchableSelect', () => {
     const select = screen.getByPlaceholderText('Select an option');
 
     expect(select).toHaveClass(
-      'h-[30px] w-full grow appearance-none border py-1.5 pl-2 pr-1 text-xs leading-tight outline-none'
+      'h-7.5 w-full grow appearance-none border py-1.5 pl-2 pr-1 text-xs leading-tight outline-none'
     );
   });
 
@@ -88,7 +88,7 @@ describe('SearchableSelect', () => {
 
     expect(button).toHaveClass('pl-1.5');
     expect(button.parentElement).toHaveClass(
-      'hover:bg-light border-light flex h-[30px] w-full items-center border-t px-2 py-1 text-xs'
+      'hover:bg-light border-light flex h-7.5 w-full items-center border-t px-2 py-1 text-xs'
     );
   });
 

--- a/packages/core/src/lib/select/__tests__/select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/select.spec.ts
@@ -11,7 +11,7 @@ describe('Select', () => {
     const select = screen.getByPlaceholderText('Select an option');
 
     expect(select).toHaveClass(
-      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+      'h-7.5 w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
     );
 
     expect(select).not.toHaveClass(
@@ -36,7 +36,7 @@ describe('Select', () => {
     const select = screen.getByPlaceholderText('Select an option');
 
     expect(select).toHaveClass(
-      'h-[30px] w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
+      'h-7.5 w-full appearance-none border px-2 py-1.5 text-xs leading-tight outline-none'
     );
 
     expect(select).toHaveClass(

--- a/packages/core/src/lib/select/multiselect.svelte
+++ b/packages/core/src/lib/select/multiselect.svelte
@@ -218,7 +218,7 @@ const handleButtonClick = () => dispatch('buttonclick');
           {#each searchedOptions as { highlight, option }, index (option)}
             <li role="presentation">
               <label
-                class={cx('flex h-[30px] w-full items-center px-2', {
+                class={cx('flex h-7.5 w-full items-center px-2', {
                   'bg-light': $navigationIndex === index,
                 })}
                 on:mouseenter={() => handleOptionFocus(index)}
@@ -256,7 +256,7 @@ const handleButtonClick = () => dispatch('buttonclick');
                 tabindex="-1"
                 role="menuitem"
                 class={cx(
-                  'flex h-[30px] w-full items-center px-2 text-xs outline-none',
+                  'flex h-7.5 w-full items-center px-2 text-xs outline-none',
                   {
                     'bg-light': $navigationIndex === searchedOptions.length,
                   }

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -174,7 +174,7 @@ $: {
               role="menuitem"
               tabindex="-1"
               class={cx(
-                'flex h-[30px] w-full items-center text-ellipsis whitespace-nowrap px-2 text-xs outline-none',
+                'flex h-7.5 w-full items-center text-ellipsis whitespace-nowrap px-2 text-xs outline-none',
                 {
                   'bg-light': $navigationIndex === index,
                 }

--- a/packages/core/src/lib/select/select-input.svelte
+++ b/packages/core/src/lib/select/select-input.svelte
@@ -47,7 +47,7 @@ $: errorClasses =
     aria-disabled={disabled ? true : undefined}
     type="text"
     class={cx(
-      'h-[30px] w-full grow appearance-none border py-1.5 pl-2 pr-1 text-xs leading-tight outline-none',
+      'h-7.5 w-full grow appearance-none border py-1.5 pl-2 pr-1 text-xs leading-tight outline-none',
       defaultClasses,
       disabledClasses,
       warnClasses,

--- a/packages/core/src/lib/select/select-menu.svelte
+++ b/packages/core/src/lib/select/select-menu.svelte
@@ -44,7 +44,7 @@ export { extraClasses as cx };
   {#if button !== undefined}
     <button
       type="button"
-      class="flex h-[30px] w-full items-center border-t border-light px-2 py-1 text-xs hover:bg-light"
+      class="flex h-7.5 w-full items-center border-t border-light px-2 py-1 text-xs hover:bg-light"
     >
       <Icon
         name={button.icon}

--- a/packages/core/src/lib/select/select.svelte
+++ b/packages/core/src/lib/select/select.svelte
@@ -71,7 +71,7 @@ $: errorClasses =
     aria-disabled={disabled ? true : undefined}
     aria-invalid={isError ? true : undefined}
     class={cx(
-      'peer h-[30px] w-full appearance-none rounded-none border px-2 py-1.5 text-xs leading-tight outline-none',
+      'peer h-7.5 w-full appearance-none rounded-none border px-2 py-1.5 text-xs leading-tight outline-none',
       defaultClasses,
       disabledClasses,
       warnClasses,

--- a/packages/core/theme.ts
+++ b/packages/core/theme.ts
@@ -70,8 +70,14 @@ export const theme = {
       cyberpunk: '#a51aff',
       hyperlink: '#0000ea',
     },
+    height: {
+      '7.5': '1.875rem',
+    },
     transitionProperty: {
       'expand-vertical': 'max-height,visibility',
+    },
+    width: {
+      '7.5': '1.875rem',
     },
     zIndex: {
       max: '1000',

--- a/packages/core/theme.ts
+++ b/packages/core/theme.ts
@@ -70,14 +70,11 @@ export const theme = {
       cyberpunk: '#a51aff',
       hyperlink: '#0000ea',
     },
-    height: {
+    spacing: {
       '7.5': '1.875rem',
     },
     transitionProperty: {
       'expand-vertical': 'max-height,visibility',
-    },
-    width: {
-      '7.5': '1.875rem',
     },
     zIndex: {
       max: '1000',


### PR DESCRIPTION
Continuing with changes from https://github.com/viamrobotics/prime/pull/357 this replaces the usage of `h-[30px]` and `w-[30px]` arbitrary classes with new utility classes.