### PR TITLE
Bump prime-core to 0.0.47

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
I must've lost my version bump in a merge. Bumping to get `RestrictedTextInput`.