### PR TITLE
Fix toggle button legend margins and ignore all things __tests__

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.48",
+  "version": "0.0.49",
   "publishConfig": {
     "access": "public"
   },
@@ -29,10 +29,9 @@
   },
   "files": [
     "dist",
-    "!dist/**/*.test.*",
-    "!dist/**/*.spec.*",
     "theme.ts",
-    "prime.css"
+    "prime.css",
+    "!__tests__"
   ],
   "peerDependencies": {
     "svelte": ">=4.0.0 <5"

--- a/packages/core/src/lib/radio.svelte
+++ b/packages/core/src/lib/radio.svelte
@@ -57,7 +57,7 @@ $: getIcon = (option: string): IconName =>
   {#if $$slots.legend}
     <legend
       class={cx(
-        cx('flex text-xs', {
+        cx('mb-1 flex text-xs', {
           'text-subtle-1': !disabled,
           'cursor-not-allowed text-disabled-dark': disabled,
           'after:ml-1 after:text-danger-dark after:content-["*"]': required,

--- a/packages/core/src/lib/toggle-buttons.svelte
+++ b/packages/core/src/lib/toggle-buttons.svelte
@@ -64,7 +64,7 @@ const handleClick = (value: string) => {
   {#if $$slots.legend}
     <legend
       class={cx(
-        cx('flex text-xs', {
+        cx('mb-1 flex text-xs', {
           'text-subtle-1': !disabled,
           'cursor-not-allowed text-disabled-dark': disabled,
         })


### PR DESCRIPTION
After seeing it in `app` I noticed the margins for the `legend`s were missing, also simplified our ignores for test files so anything in a `__tests__` directory is ignored.