### PR TITLE
Remove redundant test component doc strings and add blurb to README

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -175,6 +175,7 @@ We keep tests in a `__tests__` directory that is a sibling of the code being tes
 
 Some components require test components to render slotted children, due to limitations with rendering slots using `@testing-library`.
 
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
+See:
+
+- https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
+- https://github.com/testing-library/svelte-testing-library/issues/48

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -168,3 +168,13 @@ For easier readability, we try to use a standard ordering for component composit
   /* custom styles */
 </style>
 ```
+
+## Tests and Test Components
+
+We keep tests in a `__tests__` directory that is a sibling of the code being tested. These directories should only contain tests and test components.
+
+Some components require test components to render slotted children, due to limitations with rendering slots using `@testing-library`.
+
+  See:
+  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
+  - https://github.com/testing-library/svelte-testing-library/issues/48

--- a/packages/core/src/lib/__tests__/label.spec.svelte
+++ b/packages/core/src/lib/__tests__/label.spec.svelte
@@ -1,14 +1,3 @@
-<!-- 
-  @component
-
-  This component allows us to render a Label with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
 <script lang="ts">
 import type cx from 'classnames';
 import { Label, type LabelPosition } from '$lib';

--- a/packages/core/src/lib/__tests__/radio.spec.svelte
+++ b/packages/core/src/lib/__tests__/radio.spec.svelte
@@ -1,15 +1,3 @@
-<!-- 
-  @component
-
-  This component allows us to render a Notify with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
-
 <script lang="ts">
 import Radio from '$lib/radio.svelte';
 

--- a/packages/core/src/lib/__tests__/switch.spec.svelte
+++ b/packages/core/src/lib/__tests__/switch.spec.svelte
@@ -1,14 +1,3 @@
-<!-- 
-  @component
-
-  This component allows us to render a Notify with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
 <script lang="ts">
 import Switch from '$lib/switch.svelte';
 

--- a/packages/core/src/lib/__tests__/toggle-buttons.spec.svelte
+++ b/packages/core/src/lib/__tests__/toggle-buttons.spec.svelte
@@ -1,15 +1,3 @@
-<!-- 
-  @component
-
-  This component allows us to render a Notify with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
-
 <script lang="ts">
 import ToggleButtons from '$lib/toggle-buttons.svelte';
 

--- a/packages/core/src/lib/banner/__tests__/banner.spec.svelte
+++ b/packages/core/src/lib/banner/__tests__/banner.spec.svelte
@@ -1,15 +1,3 @@
-<!--
-  @component
-
-  This component allows us to render a Notify with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
-
 <script lang="ts">
 import type cx from 'classnames';
 import { Banner, type BannerVariantType } from '$lib';

--- a/packages/core/src/lib/context-menu/__tests__/context-menu.spec.svelte
+++ b/packages/core/src/lib/context-menu/__tests__/context-menu.spec.svelte
@@ -1,14 +1,3 @@
-<!--
-  @component
-
-  This component allows us to render a Context Menu with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
 <script lang="ts">
 import type cx from 'classnames';
 import { ContextMenu, ContextMenuItem, ContextMenuSeparator } from '$lib';

--- a/packages/core/src/lib/select/__tests__/select.spec.svelte
+++ b/packages/core/src/lib/select/__tests__/select.spec.svelte
@@ -1,14 +1,3 @@
-<!-- 
-  @component
-
-  This component allows us to render a Tooltip with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
 <script lang="ts">
 import { Select, type SelectState } from '$lib';
 

--- a/packages/core/src/lib/table/__tests__/table-row.spec.svelte
+++ b/packages/core/src/lib/table/__tests__/table-row.spec.svelte
@@ -1,14 +1,3 @@
-<!-- 
-  @component
-
-  This component allows us to render a TR with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
 <script lang="ts">
 import { TableCell, TableRow } from '$lib';
 </script>

--- a/packages/core/src/lib/table/__tests__/table.spec.svelte
+++ b/packages/core/src/lib/table/__tests__/table.spec.svelte
@@ -1,14 +1,3 @@
-<!-- 
-  @component
-
-  This component allows us to render a Table with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
 <script lang="ts">
 import type cx from 'classnames';
 import { Table, TableBody, TableRow, TableCell } from '$lib';

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
@@ -1,14 +1,3 @@
-<!--
-  @component
-
-  This component allows us to render a Tooltip with its slotted
-  children, due to limitations with rendering slots using
-  `@testing-library`.
-
-  See:
-  - https://sveltesociety.dev/recipes/testing-and-debugging/unit-testing-svelte-component
-  - https://github.com/testing-library/svelte-testing-library/issues/48
- -->
 <script lang="ts">
 import { Tooltip, type TooltipLocation, type TooltipVisibility } from '$lib';
 


### PR DESCRIPTION
Per some conversation we have decided the docs strings in test components are not providing a lot of value and mostly have become rote copy-and-paste inclusions with new code. I moved the relevant documentation to the README and removed component-level doc strings.