### PR TITLE
Remove trzy dependency from prime-blocks

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -14,8 +14,8 @@
     "check-svelte": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check-lint": "pnpm run _prettier --check && pnpm run _eslint",
     "format": "pnpm run _prettier --write",
-    "test": "svelte-kit sync && echo \"TODO: write tests for @viamrobotics/blocks\"",
-    "test:watch": "echo \"TODO: write tests for @viamrobotics/blocks\"",
+    "test": "svelte-kit sync && vitest run",
+    "test:watch": "vitest",
     "_prettier": "prettier \"**/*.{js,cjs,ts,svelte,css,json,yml,yaml,md,mdx}\"",
     "_eslint": "eslint \".*.cjs\" \"**/*.{js,cjs,ts,svelte}\""
   },

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-blocks",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -34,13 +34,12 @@
   ],
   "peerDependencies": {
     "@threlte/core": ">=6",
-    "@threlte/extras": ">=5",
+    "@threlte/extras": ">=7",
     "@viamrobotics/prime-core": ">=0.0.48",
     "@viamrobotics/three": ">=0.0.2",
     "svelte": ">=4 <5",
     "tailwindcss": ">=3",
-    "three": ">=0.150",
-    "trzy": ">=0.3.11"
+    "three": ">=0.150"
   },
   "dependencies": {
     "maplibre-gl": "^3.3.0"
@@ -82,7 +81,6 @@
     "svelte-check": "^3.5.0",
     "tailwindcss": "^3.3.3",
     "three": "^0.155.0",
-    "trzy": "^0.3.12",
     "tslib": "^2.6.1",
     "typescript": "^5.2.2",
     "vite": "^4.4.9",

--- a/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
@@ -7,33 +7,47 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial';
 
 export let length = 1;
 export let width = 0.2;
+let axesColors = ['red', 'green', 'blue'];
+
+const TOTAL_VERTICES = 9;
+const VERTEX_COMPONENTS = 3;
 
 const line = new Line2();
 const material = new LineMaterial();
 const geometry = new LineGeometry();
-const axes = ['red', 'green', 'blue'];
 const color = new THREE.Color();
-const colors = new Float32Array(27);
+const colors = new Float32Array(TOTAL_VERTICES * VERTEX_COMPONENTS);
+const positions = new Float32Array(TOTAL_VERTICES * VERTEX_COMPONENTS);
 
-for (const [index, axis] of axes.entries()) {
-  color.set(axis);
-
-  for (let j = index * 9; j < index * 9 + 9; j += 3) {
-    colors[j + 0] = color.r;
-    colors[j + 1] = color.g;
-    colors[j + 2] = color.b;
-  }
-}
-
-geometry.setColors(colors);
-
+// An arbitrary division that "feels good" using meter scale.
 $: material.linewidth = width / 100;
 
+// Assign colors per vertex
 $: {
-  const positions = new Float32Array(27);
-  positions[3] = length;
-  positions[13] = length;
-  positions[23] = length;
+  for (const [index, axis] of axesColors.entries()) {
+    color.set(axis);
+
+    const axisBufferStart = index * TOTAL_VERTICES;
+    const axisBufferEnd = axisBufferStart + TOTAL_VERTICES;
+
+    for (let j = axisBufferStart; j < axisBufferEnd; j += VERTEX_COMPONENTS) {
+      colors[j + 0] = color.r;
+      colors[j + 1] = color.g;
+      colors[j + 2] = color.b;
+    }
+  }
+
+  geometry.setColors(colors);
+}
+
+const X_AXIS_X_COMPONENT_INDEX = 3;
+const Y_AXIS_Y_COMPONENT_INDEX = 13;
+const Z_AXIS_Z_COMPONENT_INDEX = 23;
+
+$: {
+  positions[X_AXIS_X_COMPONENT_INDEX] = length;
+  positions[Y_AXIS_Y_COMPONENT_INDEX] = length;
+  positions[Z_AXIS_Z_COMPONENT_INDEX] = length;
   geometry.setPositions(positions);
 }
 </script>

--- a/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+import * as THREE from 'three';
+import { T } from '@threlte/core';
+import { Line2 } from 'three/examples/jsm/lines/Line2';
+import { LineGeometry } from 'three/examples/jsm/lines/LineGeometry';
+import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial';
+
+export let length = 1;
+export let width = 0.2;
+
+const line = new Line2();
+const material = new LineMaterial();
+const geometry = new LineGeometry();
+const axes = ['red', 'green', 'blue'];
+const color = new THREE.Color();
+const colors = new Float32Array(27);
+
+for (const [index, axis] of axes.entries()) {
+  color.set(axis);
+
+  for (let j = index * 9; j < index * 9 + 9; j += 3) {
+    colors[j + 0] = color.r;
+    colors[j + 1] = color.g;
+    colors[j + 2] = color.b;
+  }
+}
+
+geometry.setColors(colors);
+
+$: linewidth = width / 100;
+$: material.linewidth = linewidth;
+
+$: {
+  const positions = new Float32Array(27);
+  positions[3] = length;
+  positions[13] = length;
+  positions[23] = length;
+  geometry.setPositions(positions);
+}
+</script>
+
+<T is={line}>
+  <T is={geometry} />
+  <T
+    is={material}
+    alphaToCoverage
+    vertexColors
+  />
+</T>

--- a/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
@@ -27,8 +27,7 @@ for (const [index, axis] of axes.entries()) {
 
 geometry.setColors(colors);
 
-$: linewidth = width / 100;
-$: material.linewidth = linewidth;
+$: material.linewidth = width / 100;
 
 $: {
   const positions = new Float32Array(27);

--- a/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/axes-helper.svelte
@@ -7,7 +7,7 @@ import { LineMaterial } from 'three/examples/jsm/lines/LineMaterial';
 
 export let length = 1;
 export let width = 0.2;
-let axesColors = ['red', 'green', 'blue'];
+export let axesColors = ['red', 'green', 'blue'];
 
 const TOTAL_VERTICES = 9;
 const VERTEX_COMPONENTS = 3;

--- a/packages/blocks/src/lib/slam-map-2d/helpers.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/helpers.svelte
@@ -5,29 +5,30 @@
 -->
 <script lang="ts">
 import { T } from '@threlte/core';
-import { AxesHelper, GridHelper } from 'trzy';
+import { Grid } from '@threlte/extras';
 import { renderOrder } from './render-order';
+import AxesHelper from './axes-helper.svelte';
 </script>
 
-<!-- trzy.GridHelper is more performant by drawing the grid in a shader, and can have small and large cells. -->
-<T
-  is={GridHelper}
+<Grid
+  infiniteGrid
+  fadeDistance={150}
   renderOrder={renderOrder.grid}
-  color="#ddd"
+  plane="xy"
   rotation.x={Math.PI / 2}
+  cellColor="#ddd"
+  sectionColor="#ccc"
+  position.z={-0.1}
 />
 
-<!-- trzy.AxesHelper uses thick lines so that axes are more clearly displayed, and is dynamically resizable. -->
-<T
-  is={AxesHelper}
-  renderOrder={renderOrder.axes}
+<AxesHelper
   width={0.2}
   length={10_000}
 />
 
-<T.AxesHelper
-  renderOrder={renderOrder.axes}
-  width={0.2}
-  length={10_000}
-  rotation.z={Math.PI}
-/>
+<T.Group rotation.z={Math.PI}>
+  <AxesHelper
+    width={0.2}
+    length={10_000}
+  />
+</T.Group>

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
@@ -19,19 +19,23 @@ export const useRaycastClick = () => {
   const plane = new THREE.Plane();
   plane.normal.set(0, 0, -1);
 
-  const normalizedDeviceCoordinates = (x: number, y: number, vec2: THREE.Vector2) => {
+  const normalizedDeviceCoordinates = (
+    x: number,
+    y: number,
+    vec2: THREE.Vector2
+  ) => {
     const canvas = renderer.domElement;
     const rect = canvas.getBoundingClientRect();
     vec2.x = ((x - rect.x) / canvas.clientWidth) * 2 - 1;
     vec2.y = -(((y - rect.y) / canvas.clientHeight) * 2) + 1;
-  }
+  };
 
   const handleDown = (event: PointerEvent) => {
-    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerDown)
+    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerDown);
   };
 
   const handleUp = (event: MouseEvent) => {
-    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerUp)
+    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerUp);
 
     const pointerMoved = pointerDown.sub(pointerUp).lengthSq() > EPSILON;
 

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
@@ -19,18 +19,19 @@ export const useRaycastClick = () => {
   const plane = new THREE.Plane();
   plane.normal.set(0, 0, -1);
 
-  const handleDown = (event: PointerEvent) => {
+  const normalizedDeviceCoordinates = (x: number, y: number, vec2: THREE.Vector2) => {
     const canvas = renderer.domElement;
     const rect = canvas.getBoundingClientRect();
-    pointerDown.x = ((event.clientX - rect.x) / canvas.clientWidth) * 2 - 1;
-    pointerDown.y = -(((event.clientY - rect.y) / canvas.clientHeight) * 2) + 1;
+    vec2.x = ((x - rect.x) / canvas.clientWidth) * 2 - 1;
+    vec2.y = -(((y - rect.y) / canvas.clientHeight) * 2) + 1;
+  }
+
+  const handleDown = (event: PointerEvent) => {
+    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerDown)
   };
 
   const handleUp = (event: MouseEvent) => {
-    const canvas = renderer.domElement;
-    const rect = canvas.getBoundingClientRect();
-    pointerUp.x = ((event.clientX - rect.x) / canvas.clientWidth) * 2 - 1;
-    pointerUp.y = -(((event.clientY - rect.y) / canvas.clientHeight) * 2) + 1;
+    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerUp)
 
     const pointerMoved = pointerDown.sub(pointerUp).lengthSq() > EPSILON;
 

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
@@ -3,7 +3,11 @@ import { useThrelte } from '@threlte/core';
 import { createEventDispatcher, onMount } from 'svelte';
 
 interface Events {
-  /** Fires when the user clicks on the canvas */
+  /**
+   * Fires when the user clicks on the canvas, and reports
+   * the intersection of a ray cast from the mouse coordinate
+   * to an infinite xy plane at z=0.
+   */
   click: THREE.Vector3;
 }
 

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click.ts
@@ -1,0 +1,58 @@
+import * as THREE from 'three';
+import { useThrelte } from '@threlte/core';
+import { createEventDispatcher, onMount } from 'svelte';
+
+interface Events {
+  /** Fires when the user clicks on the canvas */
+  click: THREE.Vector3;
+}
+
+const EPSILON = 0.001;
+
+export const useRaycastClick = () => {
+  const { renderer, camera } = useThrelte();
+  const dispatch = createEventDispatcher<Events>();
+
+  const raycaster = new THREE.Raycaster();
+  const pointerDown = new THREE.Vector2();
+  const pointerUp = new THREE.Vector2();
+  const plane = new THREE.Plane();
+  plane.normal.set(0, 0, -1);
+
+  const handleDown = (event: PointerEvent) => {
+    const canvas = renderer.domElement;
+    const rect = canvas.getBoundingClientRect();
+    pointerDown.x = ((event.clientX - rect.x) / canvas.clientWidth) * 2 - 1;
+    pointerDown.y = -(((event.clientY - rect.y) / canvas.clientHeight) * 2) + 1;
+  };
+
+  const handleUp = (event: MouseEvent) => {
+    const canvas = renderer.domElement;
+    const rect = canvas.getBoundingClientRect();
+    pointerUp.x = ((event.clientX - rect.x) / canvas.clientWidth) * 2 - 1;
+    pointerUp.y = -(((event.clientY - rect.y) / canvas.clientHeight) * 2) + 1;
+
+    const pointerMoved = pointerDown.sub(pointerUp).lengthSq() > EPSILON;
+
+    if (pointerMoved) {
+      return;
+    }
+
+    const vec3 = new THREE.Vector3();
+
+    raycaster.setFromCamera(pointerUp, camera.current);
+    raycaster.ray.intersectPlane(plane, vec3);
+
+    dispatch('click', vec3);
+  };
+
+  onMount(() => {
+    renderer.domElement.addEventListener('pointerdown', handleDown);
+    renderer.domElement.addEventListener('click', handleUp);
+
+    return () => {
+      renderer.domElement.addEventListener('pointerdown', handleUp);
+      renderer.domElement.removeEventListener('click', handleUp);
+    };
+  });
+};

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/__tests__/normalize-device-coordinates.spec.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/__tests__/normalize-device-coordinates.spec.ts
@@ -8,10 +8,10 @@ describe('normalizeDeviceCoordinates', () => {
     clientWidth: 100,
     clientHeight: 100,
     getBoundingClientRect() {
-      return { x: 50, y: 100 } as DOMRect
+      return { x: 50, y: 100 } as DOMRect;
     },
   } as HTMLElement;
-  
+
   it('should translate a pointer position on an offset element to NDC space', () => {
     // Click near top left
     normalizeDeviceCoordinates(mockElement, 51, 101, target);

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/__tests__/normalize-device-coordinates.spec.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/__tests__/normalize-device-coordinates.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import * as THREE from 'three';
+import { normalizeDeviceCoordinates } from '../normalize-device-coordinates';
+
+describe('normalizeDeviceCoordinates', () => {
+  const target = new THREE.Vector2();
+  const mockElement = {
+    clientWidth: 100,
+    clientHeight: 100,
+    getBoundingClientRect() {
+      return { x: 50, y: 100 } as DOMRect
+    },
+  } as HTMLElement;
+  
+  it('should translate a pointer position on an offset element to NDC space', () => {
+    // Click near top left
+    normalizeDeviceCoordinates(mockElement, 51, 101, target);
+    expect(target.x).toBeCloseTo(-0.98);
+    expect(target.y).toBeCloseTo(0.98);
+
+    // Click near top right
+    normalizeDeviceCoordinates(mockElement, 149, 101, target);
+    expect(target.x).toBeCloseTo(0.98);
+    expect(target.y).toBeCloseTo(0.98);
+
+    // Click near bottom left
+    normalizeDeviceCoordinates(mockElement, 51, 199, target);
+    expect(target.x).toBeCloseTo(-0.98);
+    expect(target.y).toBeCloseTo(-0.98);
+
+    // Click near bottom right
+    normalizeDeviceCoordinates(mockElement, 149, 199, target);
+    expect(target.x).toBeCloseTo(0.98);
+    expect(target.y).toBeCloseTo(-0.98);
+  });
+});

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/index.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/index.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { useThrelte } from '@threlte/core';
 import { createEventDispatcher, onMount } from 'svelte';
+import { normalizeDeviceCoordinates } from './normalize-device-coordinates';
 
 interface Events {
   /**
@@ -14,32 +15,21 @@ interface Events {
 const EPSILON = 0.001;
 
 export const useRaycastClick = () => {
-  const { renderer, camera } = useThrelte();
   const dispatch = createEventDispatcher<Events>();
-
+  const { renderer, camera } = useThrelte();
+  const canvas = renderer.domElement;
   const raycaster = new THREE.Raycaster();
   const pointerDown = new THREE.Vector2();
   const pointerUp = new THREE.Vector2();
   const plane = new THREE.Plane();
   plane.normal.set(0, 0, -1);
 
-  const normalizedDeviceCoordinates = (
-    x: number,
-    y: number,
-    vec2: THREE.Vector2
-  ) => {
-    const canvas = renderer.domElement;
-    const rect = canvas.getBoundingClientRect();
-    vec2.x = ((x - rect.x) / canvas.clientWidth) * 2 - 1;
-    vec2.y = -(((y - rect.y) / canvas.clientHeight) * 2) + 1;
-  };
-
   const handleDown = (event: PointerEvent) => {
-    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerDown);
+    normalizeDeviceCoordinates(canvas, event.clientX, event.clientY, pointerDown);
   };
 
   const handleUp = (event: MouseEvent) => {
-    normalizedDeviceCoordinates(event.clientX, event.clientY, pointerUp);
+    normalizeDeviceCoordinates(canvas, event.clientX, event.clientY, pointerUp);
 
     const pointerMoved = pointerDown.sub(pointerUp).lengthSq() > EPSILON;
 

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/index.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/index.ts
@@ -25,7 +25,12 @@ export const useRaycastClick = () => {
   plane.normal.set(0, 0, -1);
 
   const handleDown = (event: PointerEvent) => {
-    normalizeDeviceCoordinates(canvas, event.clientX, event.clientY, pointerDown);
+    normalizeDeviceCoordinates(
+      canvas,
+      event.clientX,
+      event.clientY,
+      pointerDown
+    );
   };
 
   const handleUp = (event: MouseEvent) => {

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/normalize-device-coordinates.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/normalize-device-coordinates.ts
@@ -1,9 +1,14 @@
 export const normalizeDeviceCoordinates = (
-  element: HTMLCanvasElement,
+  element: HTMLElement,
   x: number,
   y: number,
   target: THREE.Vector2
 ) => {
+  if (element.clientWidth === 0 || element.clientHeight === 0) {
+    throw new Error(
+      'normalizeDeviceCoordinates cannot operate on a dimensionless element'
+    );
+  }
   const rect = element.getBoundingClientRect();
   target.x = ((x - rect.x) / element.clientWidth) * 2 - 1;
   target.y = -(((y - rect.y) / element.clientHeight) * 2) + 1;

--- a/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/normalize-device-coordinates.ts
+++ b/packages/blocks/src/lib/slam-map-2d/hooks/use-raycast-click/normalize-device-coordinates.ts
@@ -1,0 +1,10 @@
+export const normalizeDeviceCoordinates = (
+  element: HTMLCanvasElement,
+  x: number,
+  y: number,
+  target: THREE.Vector2
+) => {
+  const rect = element.getBoundingClientRect();
+  target.x = ((x - rect.x) / element.clientWidth) * 2 - 1;
+  target.y = -(((y - rect.y) / element.clientHeight) * 2) + 1;
+};

--- a/packages/blocks/src/lib/slam-map-2d/index.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/index.svelte
@@ -17,7 +17,6 @@
 -->
 <script lang="ts">
 import type * as THREE from 'three';
-import { createEventDispatcher } from 'svelte';
 import { Canvas } from '@threlte/core';
 import Legend from './legend.svelte';
 import Scene from './scene.svelte';
@@ -38,12 +37,6 @@ export let helpers = true;
 /** An optional motion path */
 export let motionPath: string | undefined = undefined;
 
-interface Events {
-  /** Dispatched when a user clicks within the bounding box of the pointcloud */
-  click: THREE.Vector3;
-}
-
-createEventDispatcher<Events>();
 </script>
 
 <div class="relative h-full w-full">

--- a/packages/blocks/src/lib/slam-map-2d/index.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/index.svelte
@@ -43,7 +43,7 @@ interface Events {
   click: THREE.Vector3;
 }
 
-const dispatch = createEventDispatcher<Events>();
+createEventDispatcher<Events>();
 </script>
 
 <div class="relative h-full w-full">
@@ -54,7 +54,7 @@ const dispatch = createEventDispatcher<Events>();
       {basePose}
       {destination}
       {motionPath}
-      on:click={(event) => dispatch('click', event)}
+      on:click
     />
   </Canvas>
 

--- a/packages/blocks/src/lib/slam-map-2d/index.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/index.svelte
@@ -36,7 +36,6 @@ export let helpers = true;
 
 /** An optional motion path */
 export let motionPath: string | undefined = undefined;
-
 </script>
 
 <div class="relative h-full w-full">

--- a/packages/blocks/src/lib/slam-map-2d/scene.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/scene.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 import * as THREE from 'three';
-import { T, createRawEventDispatcher, extend, useThrelte } from '@threlte/core';
+import { T, extend, useThrelte } from '@threlte/core';
 import { MapControls } from 'three/examples/jsm/controls/MapControls';
+import { useRaycastClick } from './hooks/use-raycast-click';
 import Helpers from './helpers.svelte';
 import Points from './points.svelte';
 import Marker from './marker.svelte';
@@ -16,14 +17,9 @@ export let basePose: { x: number; y: number; theta: number } | undefined =
 export let destination: THREE.Vector2 | undefined;
 export let motionPath: string | undefined;
 
-interface $$Events extends Record<string, unknown> {
-  /** Dispatched when a user clicks within the bounding box of the pointcloud */
-  click: THREE.Vector3;
-}
-
-const dispatch = createRawEventDispatcher<$$Events>();
-
 extend({ MapControls });
+
+useRaycastClick();
 
 const { renderer, camera, invalidate } = useThrelte();
 
@@ -112,7 +108,6 @@ $: updateZoom($camera as THREE.OrthographicCamera);
 <Points
   {pointcloud}
   size={pointSize}
-  on:click={(event) => dispatch('click', event)}
   on:update={handlePointsUpdate}
 />
 

--- a/packages/blocks/src/routes/+page.svelte
+++ b/packages/blocks/src/routes/+page.svelte
@@ -20,6 +20,7 @@ const fetchPointcloud = async () => {
         <SlamMap2D
           {pointcloud}
           {motionPath}
+          on:click={(event) => console.log(event.detail)}
         />
       {/await}
     </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,8 +11,8 @@ importers:
   packages/blocks:
     dependencies:
       '@threlte/extras':
-        specifier: '>=5'
-        version: 5.6.2(svelte@4.2.0)(three@0.155.0)
+        specifier: '>=7'
+        version: 7.3.0(svelte@4.2.0)(three@0.155.0)
       maplibre-gl:
         specifier: ^3.3.0
         version: 3.3.0
@@ -125,9 +125,6 @@ importers:
       three:
         specifier: ^0.155.0
         version: 0.155.0
-      trzy:
-        specifier: ^0.3.12
-        version: 0.3.12(three@0.155.0)
       tslib:
         specifier: ^2.6.1
         version: 2.6.1
@@ -4662,8 +4659,8 @@ packages:
       three: 0.155.0
     dev: true
 
-  /@threlte/extras@5.6.2(svelte@4.2.0)(three@0.155.0):
-    resolution: {integrity: sha512-7VDUtAEji3w0mlmgLwidKCnRwgD9HFaBV4INa4M1oZpXPToXYr4L1wu8agsCSr79uag6dE8whQ9tJ8qH77OzUQ==}
+  /@threlte/extras@7.3.0(svelte@4.2.0)(three@0.155.0):
+    resolution: {integrity: sha512-Q7y+a6e45PtbE+MNK4ercSTYxcXto9MZKvBkgmbJiv3kDZxSYJuhys4pKJlhKZ5Nq17ZC0txDKCg0aLKBkrF1g==}
     peerDependencies:
       svelte: '>=4'
       three: '>=0.133'
@@ -5232,7 +5229,7 @@ packages:
       eslint: 8.49.0
       eslint-config-prettier: 9.0.0(eslint@8.49.0)
       eslint-plugin-sonarjs: 0.21.0(eslint@8.49.0)
-      eslint-plugin-svelte: 2.33.1(eslint@8.49.0)(svelte@4.2.0)
+      eslint-plugin-svelte: 2.33.1(eslint@8.49.0)(svelte@4.1.2)
       eslint-plugin-tailwindcss: 3.13.0(tailwindcss@3.3.3)
       eslint-plugin-unicorn: 48.0.1(eslint@8.49.0)
     dev: true
@@ -5250,7 +5247,7 @@ packages:
         optional: true
     dependencies:
       prettier: 3.0.3
-      prettier-plugin-svelte: 3.0.3(prettier@3.0.3)(svelte@4.2.0)
+      prettier-plugin-svelte: 3.0.3(prettier@3.0.3)(svelte@4.1.2)
       prettier-plugin-tailwindcss: 0.5.4(prettier-plugin-svelte@3.0.3)(prettier@3.0.3)
     dev: true
 
@@ -10646,7 +10643,7 @@ packages:
         optional: true
     dependencies:
       prettier: 3.0.3
-      prettier-plugin-svelte: 3.0.3(prettier@3.0.3)(svelte@4.2.0)
+      prettier-plugin-svelte: 3.0.3(prettier@3.0.3)(svelte@4.1.2)
     dev: true
 
   /prettier@2.8.8:
@@ -11488,10 +11485,6 @@ packages:
       semver: 7.5.4
     dev: true
 
-  /simplex-noise@4.0.1:
-    resolution: {integrity: sha512-zl/+bdSqW7HJOQ0oDbxrNYaF4F5ik0i7M6YOYmEoIJNtg16NpvWaTTM1Y7oV/7T0jFljawLgYPS81Uu2rsfo1A==}
-    dev: true
-
   /sirv@2.0.3:
     resolution: {integrity: sha512-O9jm9BsID1P+0HOi81VpXPoDxYP374pkOLzACAoyUQ/3OUVndNpsz6wMnY2z+yOxzbllCKZrM+9QrWsv4THnyA==}
     engines: {node: '>= 10'}
@@ -12233,14 +12226,6 @@ packages:
       any-promise: 1.3.0
     dev: true
 
-  /three-mesh-bvh@0.6.3(three@0.155.0):
-    resolution: {integrity: sha512-xjuGLSI9nBATIsWcT/DnnNma5xXYyvBiXfUbhGLAFqItOlOKYF5JWsUOX+cuSAnSWovEoHzd5Emx23qKiByrlw==}
-    peerDependencies:
-      three: '>= 0.151.0'
-    dependencies:
-      three: 0.155.0
-    dev: true
-
   /three@0.155.0:
     resolution: {integrity: sha512-sNgCYmDijnIqkD/bMfk+1pHg3YzsxW7V2ChpuP6HCQ8NiZr3RufsXQr8M3SSUMjW4hG+sUk7YbyuY0DncaDTJQ==}
 
@@ -12355,16 +12340,6 @@ packages:
 
   /trough@2.1.0:
     resolution: {integrity: sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g==}
-    dev: true
-
-  /trzy@0.3.12(three@0.155.0):
-    resolution: {integrity: sha512-kVz9w9ncDk518HJ0QUKjnRE2LPLcpFbQhkiXhOyhW6mUT1WW2Rs0ouTMeIsp8A0Y5RPKHjE0rkAJb0VA4rC9VA==}
-    peerDependencies:
-      three: '*'
-    dependencies:
-      simplex-noise: 4.0.1
-      three: 0.155.0
-      three-mesh-bvh: 0.6.3(three@0.155.0)
     dev: true
 
   /ts-api-utils@1.0.1(typescript@5.2.2):


### PR DESCRIPTION
This PR removes `trzy` as a peer-dep and makes the folllowing replacements:
* Use [`@threlte/extras` Grid](https://threlte.xyz/docs/reference/extras/grid) instead
* Use an internal AxesHelper instead
* Use an internal raycaster for clicking on the slam map