### PR TITLE
Remove code-snippet theme prop

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.54",
+  "version": "0.0.55",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/__tests__/code-snippet.spec.ts
+++ b/packages/core/src/lib/__tests__/code-snippet.spec.ts
@@ -4,6 +4,7 @@ import { CodeSnippet } from '$lib';
 import { cxTestArguments, cxTestResults } from './cx-test';
 import CaptionedCodeSnippet from './code-snippet.spec.svelte';
 import userEvent from '@testing-library/user-event';
+import { escape } from 'lodash';
 
 describe('CodeSnippet', () => {
   const common = {
@@ -13,7 +14,7 @@ describe('CodeSnippet', () => {
 
   it('Renders the code snippet', () => {
     render(CodeSnippet, common);
-    expect(screen.getByText('{ my: "json" }')).toBeInTheDocument();
+    expect(screen.getByText(escape('{ my: "json" }'))).toBeInTheDocument();
   });
 
   it('Renders with the passed cx classes', () => {

--- a/packages/core/src/lib/__tests__/code-snippet.spec.ts
+++ b/packages/core/src/lib/__tests__/code-snippet.spec.ts
@@ -4,7 +4,6 @@ import { CodeSnippet } from '$lib';
 import { cxTestArguments, cxTestResults } from './cx-test';
 import CaptionedCodeSnippet from './code-snippet.spec.svelte';
 import userEvent from '@testing-library/user-event';
-import { escape } from 'lodash';
 
 describe('CodeSnippet', () => {
   const common = {
@@ -14,7 +13,7 @@ describe('CodeSnippet', () => {
 
   it('Renders the code snippet', () => {
     render(CodeSnippet, common);
-    expect(screen.getByText(escape('{ my: "json" }'))).toBeInTheDocument();
+    expect(screen.getByText(common.code)).toBeInTheDocument();
   });
 
   it('Renders with the passed cx classes', () => {

--- a/packages/core/src/lib/__tests__/code-snippet.spec.ts
+++ b/packages/core/src/lib/__tests__/code-snippet.spec.ts
@@ -26,10 +26,10 @@ describe('CodeSnippet', () => {
   });
 
   it('Renders with the copy button', async () => {
-    const copy = vi.fn();
+    const writeText = vi.fn();
     Object.defineProperty(navigator, 'clipboard', {
       value: {
-        writeText: copy,
+        writeText,
       },
     });
 
@@ -43,7 +43,7 @@ describe('CodeSnippet', () => {
 
     await userEvent.click(button);
 
-    expect(copy).toHaveBeenCalledWith(common.code);
+    expect(writeText).toHaveBeenCalledWith(common.code);
   });
 
   it('Renders without the copy button', () => {

--- a/packages/core/src/lib/__tests__/use-timeout.spec.svelte
+++ b/packages/core/src/lib/__tests__/use-timeout.spec.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+import { useTimeout } from '$lib/use-timeout';
+import { onMount } from 'svelte';
+
+export let handler: () => void;
+export let shouldClear = false;
+
+const { set, clear } = useTimeout();
+
+onMount(() => {
+  set(handler, 100);
+  if (shouldClear) {
+    clear();
+  }
+});
+</script>

--- a/packages/core/src/lib/__tests__/use-timeout.spec.ts
+++ b/packages/core/src/lib/__tests__/use-timeout.spec.ts
@@ -1,0 +1,29 @@
+import { render, waitFor } from '@testing-library/svelte';
+import { describe, expect, it, vi } from 'vitest';
+import UseTimeout from './use-timeout.spec.svelte';
+
+describe('useTimeout', () => {
+  it('should set and call a handler', async () => {
+    const handler = vi.fn();
+    render(UseTimeout, { handler });
+
+    expect(handler).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(handler).toHaveBeenCalled();
+    });
+  });
+
+  it('should set and clear a handler', async () => {
+    const handler = vi.fn();
+    render(UseTimeout, { handler, shouldClear: true });
+
+    expect(handler).not.toHaveBeenCalled();
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 200);
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/lib/browser.ts
+++ b/packages/core/src/lib/browser.ts
@@ -1,0 +1,2 @@
+/** For detecting if code is being run in the browser window. */
+export const browser = typeof window !== 'undefined';

--- a/packages/core/src/lib/code-snippet.svelte
+++ b/packages/core/src/lib/code-snippet.svelte
@@ -160,7 +160,7 @@ onMount(async () => {
     <pre class="flex-1 overflow-x-auto language-{language}"><code
         bind:this={element}
         class="language-{language}"
-        data-dependencies={dependencies.join(',')}>{escape(code)}</code
+        data-dependencies={dependencies.join(',')}>{code}</code
       ></pre>
 
     {#if showCopyButton}

--- a/packages/core/src/lib/code-snippet.svelte
+++ b/packages/core/src/lib/code-snippet.svelte
@@ -19,7 +19,7 @@ https://prismjs.com
 >
 import { highlightElement, plugins } from 'prismjs';
 import PrismPackage from 'prismjs/package.json';
-export type CodeSnippetTheme = 'vs' | 'vsc-dark-plus';
+import 'prism-themes/themes/prism-vs.min.css';
 
 const PRISM_VERSION = PrismPackage.version;
 
@@ -38,9 +38,8 @@ const COPY_STATES: Record<
 import { createEventDispatcher, onMount } from 'svelte';
 import cx from 'classnames';
 
-import IconButton from './button/icon-button.svelte';
-import { useTimeout } from './use-timeout';
-import type { IconName } from './icon/icons';
+import { IconButton, type IconName, useTimeout } from '$lib';
+import { escape } from 'lodash';
 
 /**
  * The language to use for syntax highlighting. Must be a language supported by
@@ -52,14 +51,6 @@ export let language: string;
  * The code to render in the code-snippet.
  */
 export let code: string;
-
-/**
- * The theme to use for syntax highlighting. Must be a theme provided by
- * prism-themes: https://github.com/PrismJS/prism-themes#available-themes
- *
- * Currently only the `vs` and `vsc-dark-plus` themes are supported.
- */
-export let theme: CodeSnippetTheme = 'vs';
 
 /**
  * Whether or not to show a copy-to-clipboard button.
@@ -89,7 +80,6 @@ let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
 
 const { set: setCopyTimeout } = useTimeout();
-
 let element: HTMLElement | undefined;
 
 $: copyState = 'copy' as CodeSnippetCopyState;
@@ -127,7 +117,7 @@ const highlight = () => {
      * We need to reset the inner HTML of the element to the raw value of
      * `code` so it can rescanned for highlighting from the raw.
      */
-    element.innerHTML = code;
+    element.innerHTML = escape(code);
     highlightElement(element);
   }
 };
@@ -137,14 +127,7 @@ $: if (code) {
 }
 
 onMount(async () => {
-  // This throws a warning but it is a lie: https://github.com/vitejs/vite/issues/12001
-  const glob = import.meta.glob('/node_modules/prism-themes/themes/*.css');
-  const importTheme =
-    glob[`/node_modules/prism-themes/themes/prism-${theme}.min.css`];
-
   try {
-    await importTheme?.();
-
     /**
      * After the HTML is loaded in the DOM, we can use the autoloader to manage
      * scanning for languages and including the components properly
@@ -172,17 +155,12 @@ onMount(async () => {
     <figcaption><slot name="caption" /></figcaption>
   {/if}
 
-  <div
-    class={cx('flex gap-x-4 p-2', {
-      'bg-gray-9': theme === 'vsc-dark-plus',
-      'bg-light': theme === 'vs',
-    })}
-  >
+  <div class="flex gap-x-4 bg-light p-2">
     <!-- The formatting here is intentional to preserve the formatting of `code` -->
-    <pre class="flex-1 overflow-x-auto"><code
+    <pre class="flex-1 overflow-x-auto language-{language}"><code
         bind:this={element}
         class="language-{language}"
-        data-dependencies={dependencies.join(',')}>{code}</code
+        data-dependencies={dependencies.join(',')}>{escape(code)}</code
       ></pre>
 
     {#if showCopyButton}
@@ -197,24 +175,22 @@ onMount(async () => {
   </div>
 </figure>
 
-{#if theme}
-  <style>
-  /* Theme overrides */
-  figure pre[class*='language-'],
-  figure pre[class*='language-'] > code[class*='language-'] {
-    margin: 0;
-    border: none;
-    background: inherit;
-  }
+<style>
+/* Theme overrides */
+figure pre[class*='language-'],
+figure pre[class*='language-'] > code[class*='language-'] {
+  margin: 0;
+  border: none;
+  background: inherit;
+}
 
-  figure pre[class*='language-'] {
-    padding: 0;
-    padding-left: 0.5rem;
-    padding-top: 0.5rem;
-  }
+figure pre[class*='language-'] {
+  padding: 0;
+  padding-left: 0.5rem;
+  padding-top: 0.5rem;
+}
 
-  figure pre[class*='language-'] > code[class*='language-'] {
-    font-family: 'Roboto Mono Variable', 'Roboto Mono', ui-monospace, monospace;
-  }
-  </style>
-{/if}
+figure pre[class*='language-'] > code[class*='language-'] {
+  font-family: 'Roboto Mono Variable', 'Roboto Mono', ui-monospace, monospace;
+}
+</style>

--- a/packages/core/src/lib/input/restricted-text-input.svelte
+++ b/packages/core/src/lib/input/restricted-text-input.svelte
@@ -48,13 +48,11 @@ const hideInvalid = () => {
 };
 
 const showInvalid = () => {
-  clearTooltipTimeout();
   validationState = 'invalid';
   setTooltipTimeout(hideInvalid, tooltipDurationMs);
 };
 
 const remindInvalid = () => {
-  clearTooltipTimeout();
   validationState = 'invalid-remind';
   setTooltipTimeout(showInvalid, wiggleDurationMs);
 };

--- a/packages/core/src/lib/use-timeout.ts
+++ b/packages/core/src/lib/use-timeout.ts
@@ -1,28 +1,34 @@
-import { onDestroy, onMount } from 'svelte';
+import { onMount } from 'svelte';
+import { browser } from './browser';
 
-export const useTimeout = () => {
-  let mounted = false;
+export interface UseTimeout {
+  set: (handler: () => void, timeout: number) => void;
+  clear: () => void;
+}
+
+const NO_OP: UseTimeout = {
+  set: () => ({}),
+  clear: () => ({}),
+};
+
+export const useTimeout = (): UseTimeout => {
+  if (!browser) {
+    return NO_OP;
+  }
+
   let timeoutId: number;
 
   const clear = () => {
-    if (mounted) {
-      window.clearTimeout(timeoutId);
-    }
+    window.clearTimeout(timeoutId);
   };
 
   const set = (handler: () => void, timeout: number) => {
-    if (mounted) {
-      timeoutId = window.setTimeout(handler, timeout);
-    }
+    clear();
+    timeoutId = window.setTimeout(handler, timeout);
   };
 
   onMount(() => {
-    mounted = true;
-  });
-
-  onDestroy(() => {
-    clear();
-    mounted = false;
+    return () => clear();
   });
 
   return { set, clear };


### PR DESCRIPTION
Per this conversation: https://github.com/viamrobotics/prime/pull/411#discussion_r1370854790

![image](https://github.com/viamrobotics/prime/assets/1930371/908fff8a-b722-4f1c-a814-0d5af105728e)


The dark theme does not work well for JSON, which intend to use this code-snippet for frequently. If we want to introduce a dark mode, we should probably think about that more comprehensively.

Also, after we introduced the reactivity statement to rehighligh on code changes, we need to start escaping the `code` passed to this component when setting it as the `innerHtml` of the `element`.

- [x] Add tests for `use-timeout`