### PR TITLE
Fix tooltip positioning

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.56",
+  "version": "0.0.57",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/tooltip/tooltip-styles.ts
+++ b/packages/core/src/lib/tooltip/tooltip-styles.ts
@@ -160,7 +160,7 @@ const calculateStyle = async (state: State): Promise<TooltipStyles> => {
       placement: location,
       middleware: [
         offset(7),
-        flip({ fallbackAxisSideDirection: 'start' }),
+        flip({ fallbackAxisSideDirection: 'start', crossAxis: false }),
         shift({ padding: 5 }),
         arrowMiddleware({ element: arrow }),
       ],


### PR DESCRIPTION
I found a situation where floating-ui was not respecting the passed in location. After reading the docs, I found the [combining with shift](https://floating-ui.com/docs/flip#combining-with-shift) section of the `flip` docs:

> If `shift()` is in use in the middleware array, you may desire to disable `crossAxis` overflow checking, which will allow `shift()` to perform its work without falling back to the opposite axis (therefore preserving the original axis as best as possible):
>
> If your placement is not edge aligned, disabling it is usually a good choice.

We use `shift` with `flip`, so this PR follows the doc's advice, which fixes the mispositioning in my testing
