### PR TITLE
APP-3028: add opaque grey variants

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "svelte.enable-ts-plugin": true,
+  "eslint.probe": [
+    "javascript",
+    "javascriptreact",
+    "typescript",
+    "typescriptreact",
+    "html",
+    "vue",
+    "markdown",
+    "svelte"
+  ],
+  "eslint.validate": ["svelte"],
+  "prettier.documentSelectors": ["**/*.svelte"],
+  "prettier.singleQuote": true,
+  "prettier.jsxSingleQuote": true,
+  "prettier.singleAttributePerLine": true,
+  "tailwindCSS.classAttributes": ["class", "cx"],
+  "tailwindCSS.experimental.classRegex": [
+    ["cx\\(([\\S\\s]*?)\\)", "'([^']*)'"]
+  ],
+  "[svelte]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/button/button.svelte
+++ b/packages/core/src/lib/button/button.svelte
@@ -64,7 +64,7 @@ $: handleDisabled = preventHandler(disabled);
         variant === 'primary' && !disabled,
       'border-gray-9 bg-gray-9 text-white hover:border-black hover:bg-black active:bg-[#000]':
         variant === 'dark' && !disabled,
-      'border-transparent text-default hover:bg-[rgba(0,0,0,0.04)] active:border-[rgba(0,0,0,0.08)] active:bg-[rgba(0,0,0,0.08)]':
+      'border-transparent text-default hover:bg-ghost-light active:border-ghost-medium active:bg-ghost-medium':
         variant === 'ghost' && !disabled,
       'border-danger-dark bg-danger-dark text-white hover:bg-[#aa2a2b] active:bg-[#9e2728]':
         variant === 'danger' && !disabled,

--- a/packages/core/src/lib/button/button.svelte
+++ b/packages/core/src/lib/button/button.svelte
@@ -1,6 +1,6 @@
 <!--
 @component
-  
+
 For user triggered actions.
 
 ```svelte
@@ -64,7 +64,7 @@ $: handleDisabled = preventHandler(disabled);
         variant === 'primary' && !disabled,
       'border-gray-9 bg-gray-9 text-white hover:border-black hover:bg-black active:bg-[#000]':
         variant === 'dark' && !disabled,
-      'active-border-[rgba(0,0,0,0.08)] border-transparent text-default hover:bg-[rgba(0,0,0,0.04)] active:bg-[rgba(0,0,0,0.08)]':
+      'border-transparent text-default hover:bg-[rgba(0,0,0,0.04)] active:border-[rgba(0,0,0,0.08)] active:bg-[rgba(0,0,0,0.08)]':
         variant === 'ghost' && !disabled,
       'border-danger-dark bg-danger-dark text-white hover:bg-[#aa2a2b] active:bg-[#9e2728]':
         variant === 'danger' && !disabled,

--- a/packages/core/theme.ts
+++ b/packages/core/theme.ts
@@ -58,6 +58,10 @@ export const theme = {
       'disabled-dark': '#9c9ca4',
       'disabled-light': '#f2f2f4',
 
+      // Opaque grayscale
+      'ghost-light': 'rgba(0,0,0,0.04)',
+      'ghost-medium': 'rgba(0,0,0,0.08)',
+
       // Brand design colors
       'power-wire': '#ff0047',
       pcb: '#00501f',

--- a/packages/legacy/package.json
+++ b/packages/legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "license": "Apache-2.0",
   "type": "module",
   "files": [

--- a/packages/legacy/src/elements/button/button.svelte
+++ b/packages/legacy/src/elements/button/button.svelte
@@ -81,7 +81,7 @@ const handleParentClick = (event: PointerEvent) => {
         variant === 'primary',
       'border-gray-9 bg-gray-9 text-white hover:border-black hover:bg-black active:bg-[#000]':
         variant === 'inverse-primary',
-      'active:border-ghost-medium hover:bg-ghost-light active:bg-ghost-medium border-transparent':
+      'border-transparent hover:bg-ghost-light active:border-ghost-medium active:bg-ghost-medium':
         variant === 'ghost' || variant === 'icon' || variant === 'icon-danger',
       'border-danger-dark bg-danger-dark text-white hover:bg-[#aa2a2b] active:bg-[#9e2728]':
         variant === 'danger',

--- a/packages/legacy/src/elements/button/button.svelte
+++ b/packages/legacy/src/elements/button/button.svelte
@@ -81,7 +81,7 @@ const handleParentClick = (event: PointerEvent) => {
         variant === 'primary',
       'border-gray-9 bg-gray-9 text-white hover:border-black hover:bg-black active:bg-[#000]':
         variant === 'inverse-primary',
-      'active-border-[rgba(0,0,0,0.08)] border-transparent hover:bg-[rgba(0,0,0,0.04)] active:bg-[rgba(0,0,0,0.08)]':
+      'active:border-ghost-medium hover:bg-ghost-light active:bg-ghost-medium border-transparent':
         variant === 'ghost' || variant === 'icon' || variant === 'icon-danger',
       'border-danger-dark bg-danger-dark text-white hover:bg-[#aa2a2b] active:bg-[#9e2728]':
         variant === 'danger',


### PR DESCRIPTION
## Overview

After talking with Nat, this PR adds two colors to our scale that are common in our codebase and have been popping up in new code: `rgba(0, 0, 0, 0.04)` and `rgba(0, 0, 0, 0.08)` - aka the hover and active variants for the ghost button.

I'm open to whatever names, but I went with `ghost-light` and `ghost-medium`.

## Change log

- Add `ghost-light` and `ghost-medium` color variants
- Add `.vscode/settings` to git tracking for:
    - Use `typescript` from `node_modules`
    - Use `prettier` for formatting Svelte
    - Use `eslint` for checking Svelte
    - Add `cx` prop and `cx()` function to Tailwind intellisense 