### PR TITLE
RSDK-4836 Add control to navigation map to follow the base position

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-blocks",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blocks/src/lib/navigation-map/components/map.svelte
+++ b/packages/blocks/src/lib/navigation-map/components/map.svelte
@@ -36,6 +36,23 @@ const toggleTileset = () => {
 let didHoverTooltip = Boolean(
   localStorage.getItem('navigation-service-card-tooltip-hovered')
 );
+
+let isFollowingBase = false;
+const followBase = () => {
+  if (baseGeoPose && isFollowingBase) {
+    map?.setCenter(baseGeoPose);
+    requestAnimationFrame(followBase);
+  }
+};
+
+const startFollowingBase = () => {
+  isFollowingBase = true;
+  requestAnimationFrame(followBase);
+};
+
+const stopFollowingBase = () => {
+  isFollowingBase = false;
+};
 </script>
 
 <div class="relative h-full w-full items-stretch sm:flex">
@@ -103,15 +120,31 @@ let didHoverTooltip = Boolean(
       <Button on:click={toggleTileset}>
         {satellite ? 'Map' : 'Satellite'}
       </Button>
-      <CenterInputs />
-    </div>
-
-    <div class="absolute bottom-12 right-3 z-10">
       <ToggleButtons
         options={['2D', '3D']}
         selected={$view}
         on:input={handleViewSelect}
       />
+      <CenterInputs />
+    </div>
+
+    <div class="absolute bottom-10 right-2 z-10">
+      <Button
+        disabled={!baseGeoPose}
+        on:click={() => {
+          if (isFollowingBase) {
+            stopFollowingBase();
+          } else {
+            startFollowingBase();
+          }
+        }}
+      >
+        <Icon
+          name={isFollowingBase
+            ? 'navigation-variant'
+            : 'navigation-variant-outline'}
+        />
+      </Button>
     </div>
   </MapLibre>
 </div>

--- a/packages/core/src/lib/icon/icons.ts
+++ b/packages/core/src/lib/icon/icons.ts
@@ -5,6 +5,7 @@ import * as MDI from '@mdi/js';
  * e.g. 'account-multiple' for MDI.mdiAccountMultiple
  */
 export const paths = {
+  'account-group-outline': MDI.mdiAccountGroupOutline,
   'account-multiple': MDI.mdiAccountMultiple,
   'alert-circle-outline': MDI.mdiAlertCircleOutline,
   'alert-circle': MDI.mdiAlertCircle,
@@ -27,10 +28,10 @@ export const paths = {
   cancel: MDI.mdiCancel,
   'check-circle': MDI.mdiCheckCircle,
   check: MDI.mdiCheck,
-  'chevron-up': MDI.mdiChevronUp,
-  'chevron-right': MDI.mdiChevronRight,
   'chevron-down': MDI.mdiChevronDown,
   'chevron-left': MDI.mdiChevronLeft,
+  'chevron-right': MDI.mdiChevronRight,
+  'chevron-up': MDI.mdiChevronUp,
   close: MDI.mdiClose,
   'code-braces': MDI.mdiCodeBraces,
   cog: MDI.mdiCog,
@@ -38,6 +39,8 @@ export const paths = {
   'content-duplicate': MDI.mdiContentDuplicate,
   'content-save-outline': MDI.mdiContentSaveOutline,
   'credit-card-outline': MDI.mdiCreditCardOutline,
+  'database-outline': MDI.mdiDatabaseOutline,
+  domain: MDI.mdiDomain,
   'dots-horizontal': MDI.mdiDotsHorizontal,
   download: MDI.mdiDownload,
   earth: MDI.mdiEarth,
@@ -55,6 +58,8 @@ export const paths = {
   magnify: MDI.mdiMagnify,
   menu: MDI.mdiMenu,
   minus: MDI.mdiMinus,
+  'navigation-variant-outline': MDI.mdiNavigationVariantOutline,
+  'navigation-variant': MDI.mdiNavigationVariant,
   'open-in-new': MDI.mdiOpenInNew,
   'package-variant-closed': MDI.mdiPackageVariantClosed,
   'pause-circle-outline': MDI.mdiPauseCircleOutline,
@@ -65,6 +70,7 @@ export const paths = {
   'radiobox-indeterminate-variant': MDI.mdiRadioboxIndeterminateVariant,
   'radiobox-marked': MDI.mdiRadioboxMarked,
   refresh: MDI.mdiRefresh,
+  'robot-outline': MDI.mdiRobotOutline,
   'selection-ellipse': MDI.mdiSelectionEllipse,
   send: MDI.mdiSend,
   'stop-circle-outline': MDI.mdiStopCircleOutline,
@@ -73,10 +79,6 @@ export const paths = {
   twitter: MDI.mdiTwitter,
   undo: MDI.mdiUndo,
   'video-outline': MDI.mdiVideoOutline,
-  'account-group-outline': MDI.mdiAccountGroupOutline,
-  'robot-outline': MDI.mdiRobotOutline,
-  domain: MDI.mdiDomain,
-  'database-outline': MDI.mdiDatabaseOutline,
 } as const;
 
 /**


### PR DESCRIPTION
This follows the base when the user toggles the new button in the bottom right.

Note: this does not stop following the base when the user interacts with the map. MapLibre fires move events during `map.setCenter` and blocks drag events during move - I'm not sure there's a way to get around this. The user will need to toggle the button to stop following and then move the map. Zoom still works while following.

## Change log

- Moved 2D/3D buttons to top row
- Added `navigation-variant` and `navigation-variant-outline` icons
    - Sorted icon names alphabetically
- Added button to toggle "follow base" mode in bottom right
- Added `rAF` loop to follow the base position

## Review requests

Please pull this down and give it a try! (We need a test environment!)