### PR TITLE
fix mobile layout for notifications

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.60",
+  "version": "0.0.61",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/banner/banner.svelte
+++ b/packages/core/src/lib/banner/banner.svelte
@@ -97,11 +97,13 @@ $: {
   <div class="relative flex w-full justify-between gap-2 p-3">
     <div class="flex gap-3">
       {#if icon}
-        <Icon
-          size="lg"
-          name={icon}
-          cx={iconClasses}
-        />
+        <div class="w-[18px]">
+          <Icon
+            size="lg"
+            name={icon}
+            cx={iconClasses}
+          />
+        </div>
       {/if}
 
       <div class="flex flex-col">

--- a/packages/core/src/lib/notification/notification-container.svelte
+++ b/packages/core/src/lib/notification/notification-container.svelte
@@ -28,7 +28,7 @@ $: pageIsVisible.set(visibilityState === 'visible');
 <div
   role="alert"
   aria-label="Notifications"
-  class="pointer-events-none fixed bottom-auto left-auto right-6 top-6 z-[9999] m-0 p-0"
+  class="pointer-events-none fixed bottom-auto left-auto right-0 top-6 z-[9999] m-0 p-0 sm:right-6"
 >
   <ul>
     {#each $notifications as { id, pause, resume, ...notification } (id)}

--- a/packages/core/src/lib/notification/notification-item.svelte
+++ b/packages/core/src/lib/notification/notification-item.svelte
@@ -11,7 +11,7 @@ export let dismiss: () => unknown;
 
 <Banner
   exitable
-  cx="pointer-events-auto relative mb-2 w-[360px]"
+  cx="pointer-events-auto relative mb-2 w-screen sm:w-[360px]"
   on:close={dismiss}
   progress={$progress}
   {variant}


### PR DESCRIPTION
Layout fix for notifications (mobile now is 100% screen width)
![image](https://github.com/viamrobotics/prime/assets/17263/14e01c02-69f8-4e5e-9978-b8b353ff1318)

Bug fix when text wraps:
<img width="471" alt="image" src="https://github.com/viamrobotics/prime/assets/17263/d97a74dc-cfad-452e-ac1b-938a1bc65e44">

Current bug when text wraps:
![image](https://github.com/viamrobotics/prime/assets/17263/297e4926-77b0-471a-9580-68e9c08f45e2)

