### PR TITLE
APP-3122: make floating menu controlled, add aria props

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.66",
+  "version": "0.0.67",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/context-menu/__tests__/floating-menu.spec.svelte
+++ b/packages/core/src/lib/context-menu/__tests__/floating-menu.spec.svelte
@@ -8,6 +8,7 @@ const handleChange = (nextIsOpen: boolean) => (isOpen = nextIsOpen);
 
 <FloatingMenu
   {isOpen}
+  label="cool menu"
   onChange={handleChange}
 >
   <span slot="control">

--- a/packages/core/src/lib/context-menu/__tests__/floating-menu.spec.svelte
+++ b/packages/core/src/lib/context-menu/__tests__/floating-menu.spec.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
 import FloatingMenu from '../floating-menu.svelte';
 import ContextMenuItem from '../context-menu-item.svelte';
+
+let isOpen = false;
+const handleChange = (nextIsOpen: boolean) => (isOpen = nextIsOpen);
 </script>
 
-<FloatingMenu>
-  <span
-    slot="control"
-    let:isOpen
-  >
+<FloatingMenu
+  {isOpen}
+  onChange={handleChange}
+>
+  <span slot="control">
     {isOpen ? 'close' : 'open'}
   </span>
-  <svelte:fragment
-    slot="items"
-    let:closeMenu
-  >
-    <ContextMenuItem on:click={closeMenu}>item</ContextMenuItem>
+  <svelte:fragment slot="items">
+    <ContextMenuItem on:click={() => (isOpen = false)}>item</ContextMenuItem>
   </svelte:fragment>
 </FloatingMenu>
 <span data-testid="outside-element" />

--- a/packages/core/src/lib/context-menu/__tests__/floating-menu.spec.ts
+++ b/packages/core/src/lib/context-menu/__tests__/floating-menu.spec.ts
@@ -14,7 +14,7 @@ describe('<FloatingMenu> component', () => {
   it('should open and close a menu when the control is clicked', async () => {
     render(Subject);
 
-    const control = screen.getByRole('button', { name: /open/iu });
+    const control = screen.getByRole('button', { name: /cool menu/iu });
     let menu = screen.queryByRole('menu');
     let item = screen.queryByRole('menuitem');
 
@@ -41,7 +41,7 @@ describe('<FloatingMenu> component', () => {
   it('should pass aria props to the control', async () => {
     render(Subject);
 
-    const control = screen.getByRole('button', { name: /open/iu });
+    const control = screen.getByRole('button', { name: /cool menu/iu });
 
     expect(control).toHaveAttribute('aria-haspopup', 'menu');
     expect(control).toHaveAttribute('aria-expanded', 'false');
@@ -50,6 +50,7 @@ describe('<FloatingMenu> component', () => {
     const menu = screen.getByRole('menu');
 
     expect(menu).toHaveAttribute('id', expect.any(String));
+    expect(menu).toHaveAccessibleName(/cool menu/iu);
     expect(control).toHaveAttribute('aria-controls', menu.id);
     expect(control).toHaveAttribute('aria-expanded', 'true');
   });
@@ -57,7 +58,7 @@ describe('<FloatingMenu> component', () => {
   it('should close the menu if escape is pressed', async () => {
     render(Subject);
 
-    const control = screen.getByRole('button', { name: /open/iu });
+    const control = screen.getByRole('button', { name: /cool menu/iu });
 
     await user.click(control);
     await user.keyboard('{Escape}');
@@ -69,7 +70,7 @@ describe('<FloatingMenu> component', () => {
   it('should close the menu on click outside', async () => {
     render(Subject);
 
-    const control = screen.getByRole('button', { name: /open/iu });
+    const control = screen.getByRole('button', { name: /cool menu/iu });
     const outside = screen.getByTestId('outside-element');
 
     await user.click(control);
@@ -82,7 +83,7 @@ describe('<FloatingMenu> component', () => {
   it('should pass a close menu handler to the items', async () => {
     render(Subject);
 
-    const control = screen.getByRole('button', { name: /open/iu });
+    const control = screen.getByRole('button', { name: /cool menu/iu });
     await user.click(control);
 
     const item = screen.getByRole('menuitem');

--- a/packages/core/src/lib/context-menu/context-menu.svelte
+++ b/packages/core/src/lib/context-menu/context-menu.svelte
@@ -17,6 +17,12 @@ import cx from 'classnames';
 /** ID attribute of the menu element. */
 export let id: string;
 
+/** Accessible label of the menu. */
+export let label: string | undefined = undefined;
+
+/** ID of the element ID that labels the menu. */
+export let labeledBy: string | undefined = undefined;
+
 /** Additional CSS classes to pass to the menu. */
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
@@ -24,6 +30,8 @@ export { extraClasses as cx };
 
 <div
   {id}
+  aria-label={label}
+  aria-labelledby={labeledBy}
   role="menu"
   class={cx(
     'border border-medium bg-white py-1 shadow-sm filter-none',

--- a/packages/core/src/lib/context-menu/context-menu.svelte
+++ b/packages/core/src/lib/context-menu/context-menu.svelte
@@ -21,7 +21,7 @@ export let id: string;
 export let label: string | undefined = undefined;
 
 /** ID of the element ID that labels the menu. */
-export let labeledBy: string | undefined = undefined;
+export let labelledBy: string | undefined = undefined;
 
 /** Additional CSS classes to pass to the menu. */
 let extraClasses: cx.Argument = '';
@@ -31,7 +31,7 @@ export { extraClasses as cx };
 <div
   {id}
   aria-label={label}
-  aria-labelledby={labeledBy}
+  aria-labelledby={labelledBy}
   role="menu"
   class={cx(
     'border border-medium bg-white py-1 shadow-sm filter-none',

--- a/packages/core/src/lib/context-menu/floating-menu.svelte
+++ b/packages/core/src/lib/context-menu/floating-menu.svelte
@@ -5,20 +5,22 @@ import { clickOutside } from '$lib/click-outside';
 import { floatingStyle, type FloatingMenuPlacement } from './floating-style';
 import ContextMenu from './context-menu.svelte';
 
+export let isOpen: boolean;
 export let placement: FloatingMenuPlacement = 'bottom-start';
 export let offset = 0;
 export let buttonCX: cx.Argument = '';
 export let menuCX: cx.Argument = '';
+export let label: string | undefined = undefined;
+export let describedBy: string | undefined = undefined;
+export let onChange: (isOpen: boolean) => unknown;
 
 const menuID = uniqueId('floating-menu');
 const style = floatingStyle();
+const openMenu = () => onChange(true);
+const closeMenu = () => onChange(false);
 
-let isOpen = false;
 let controlElement: HTMLElement | undefined;
 let menuElement: HTMLElement | undefined;
-
-const openMenu = () => (isOpen = true);
-const closeMenu = () => (isOpen = false);
 
 const handleClickOutside = (element: Element) => {
   if (!controlElement?.contains(element)) {
@@ -36,20 +38,19 @@ const handleEscape = (event: KeyboardEvent) => {
 $: style.register({ controlElement, menuElement, placement, offset });
 </script>
 
-<svelte:document on:keydown={isOpen ? handleEscape : undefined} />
+<svelte:window on:keydown={isOpen ? handleEscape : undefined} />
 
 <button
   class={cx(buttonCX)}
   aria-haspopup="menu"
   aria-controls={menuID}
   aria-expanded={isOpen}
+  aria-label={label}
+  aria-describedby={describedBy}
   on:click={isOpen ? closeMenu : openMenu}
   bind:this={controlElement}
 >
-  <slot
-    name="control"
-    {isOpen}
-  />
+  <slot name="control" />
 </button>
 
 {#if isOpen}
@@ -65,10 +66,7 @@ $: style.register({ controlElement, menuElement, placement, offset });
       id={menuID}
       cx={menuCX}
     >
-      <slot
-        name="items"
-        {closeMenu}
-      />
+      <slot name="items" />
     </ContextMenu>
   </div>
 {/if}

--- a/packages/core/src/lib/context-menu/floating-menu.svelte
+++ b/packages/core/src/lib/context-menu/floating-menu.svelte
@@ -6,14 +6,15 @@ import { floatingStyle, type FloatingMenuPlacement } from './floating-style';
 import ContextMenu from './context-menu.svelte';
 
 export let isOpen: boolean;
+export let label: string | undefined = undefined;
+export let describedBy: string | undefined = undefined;
 export let placement: FloatingMenuPlacement = 'bottom-start';
 export let offset = 0;
 export let buttonCX: cx.Argument = '';
 export let menuCX: cx.Argument = '';
-export let label: string | undefined = undefined;
-export let describedBy: string | undefined = undefined;
 export let onChange: (isOpen: boolean) => unknown;
 
+const buttonID = uniqueId('floating-menu-control');
 const menuID = uniqueId('floating-menu');
 const style = floatingStyle();
 const openMenu = () => onChange(true);
@@ -41,6 +42,7 @@ $: style.register({ controlElement, menuElement, placement, offset });
 <svelte:window on:keydown={isOpen ? handleEscape : undefined} />
 
 <button
+  id={buttonID}
   class={cx(buttonCX)}
   aria-haspopup="menu"
   aria-controls={menuID}
@@ -64,6 +66,7 @@ $: style.register({ controlElement, menuElement, placement, offset });
   >
     <ContextMenu
       id={menuID}
+      labeledBy={buttonID}
       cx={menuCX}
     >
       <slot name="items" />

--- a/packages/core/src/lib/context-menu/floating-menu.svelte
+++ b/packages/core/src/lib/context-menu/floating-menu.svelte
@@ -66,7 +66,7 @@ $: style.register({ controlElement, menuElement, placement, offset });
   >
     <ContextMenu
       id={menuID}
-      labeledBy={buttonID}
+      labelledBy={buttonID}
       cx={menuCX}
     >
       <slot name="items" />

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -48,6 +48,7 @@ provideNotify();
 let buttonClickedTimes = 0;
 let preventHandlerDisabled = true;
 let modalOpen = false;
+let floatingMenuOpen = false;
 
 const handleTogglePreventHandler = (event: CustomEvent<boolean>) => {
   preventHandlerDisabled = event.detail;
@@ -59,6 +60,10 @@ const handleCloseModal = () => {
 
 const handleOpenModal = () => {
   modalOpen = true;
+};
+
+const handleFloatingMenuChange = (isOpen: boolean) => {
+  floatingMenuOpen = isOpen;
 };
 
 const notify = useNotify();
@@ -699,14 +704,13 @@ const htmlSnippet = `
     </ContextMenu>
 
     <FloatingMenu
+      isOpen={floatingMenuOpen}
       placement="top-start"
       offset={4}
+      onChange={handleFloatingMenuChange}
     >
-      <svelte:fragment
-        slot="control"
-        let:isOpen
-      >
-        {isOpen ? 'Close menu' : 'Open menu'}
+      <svelte:fragment slot="control">
+        {floatingMenuOpen ? 'Close menu' : 'Open menu'}
       </svelte:fragment>
       <svelte:fragment slot="items">
         <ContextMenuItem>label 1</ContextMenuItem>

--- a/packages/storybook/src/stories/context-menu.stories.svelte
+++ b/packages/storybook/src/stories/context-menu.stories.svelte
@@ -9,6 +9,12 @@ import {
 } from '@viamrobotics/prime-core';
 
 const menuID = uniqueId('context-menu');
+
+let floatingMenuOpen = false;
+
+const setFloatingMenuOpen = (isOpen: boolean) => {
+  floatingMenuOpen = isOpen;
+};
 </script>
 
 <Meta title="Elements/Context menu" />
@@ -32,17 +38,13 @@ const menuID = uniqueId('context-menu');
   <FloatingMenu
     placement="bottom-start"
     offset={4}
+    isOpen={floatingMenuOpen}
+    onChange={setFloatingMenuOpen}
   >
-    <svelte:fragment
-      slot="control"
-      let:isOpen
-    >
-      {isOpen ? 'Close menu' : 'Open menu'}
+    <svelte:fragment slot="control">
+      {floatingMenuOpen ? 'Close menu' : 'Open menu'}
     </svelte:fragment>
-    <svelte:fragment
-      slot="items"
-      let:closeMenu
-    >
+    <svelte:fragment slot="items">
       <ContextMenuItem>Just a label</ContextMenuItem>
       <ContextMenuItem icon="trash-can-outline">With icon</ContextMenuItem>
       <ContextMenuSeparator />
@@ -50,7 +52,7 @@ const menuID = uniqueId('context-menu');
       <ContextMenuItem
         icon="close"
         variant="danger"
-        on:click={closeMenu}
+        on:click={() => setFloatingMenuOpen(false)}
       >
         Danger
       </ContextMenuItem>


### PR DESCRIPTION
This PR makes two changes to the `<FloatingMenu>` component required by work on APP-3122:

- We need to be able to add accessible attributes to the control element to add a tooltip
- We need to control the open state of the menu to set styles properly