### PR TITLE
RSDK-4028: Render points as a sphere

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-blocks",
-  "version": "0.0.18",
+  "version": "0.0.19",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blocks/src/lib/navigation-map/components/obstacle.svelte
+++ b/packages/blocks/src/lib/navigation-map/components/obstacle.svelte
@@ -194,23 +194,27 @@ useMapLibreEvent('mousedown', handleMapPointerDown);
         />
       {/if}
     {:else if geometry.type === 'sphere'}
+      <!--
+        Points are defined as a sphere with radius 0.
+        Those points use sensible defaults defined below.
+      -->
       {#if active}
         <AxesHelper
-          thickness={geometry.radius / 100}
-          length={geometry.radius * 2}
+          thickness={geometry.radius / 100 || 0.05}
+          length={geometry.radius * 2 || 10}
         />
       {/if}
 
       {#if $view === '3D'}
         <T.SphereGeometry
           computeBounding={name}
-          args={[geometry.radius]}
+          args={[geometry.radius || 5]}
           on:create={handleGeometryCreate}
         />
       {:else}
         <T.CircleGeometry
           computeBounding={name}
-          args={[geometry.radius]}
+          args={[geometry.radius || 5]}
           on:create={handleGeometryCreate}
         />
       {/if}

--- a/packages/blocks/src/routes/navigation-map.svelte
+++ b/packages/blocks/src/routes/navigation-map.svelte
@@ -111,6 +111,22 @@ const obstacles: Obstacle[] = [
     color: theme.extend.colors.cyberpunk,
     label: 'static',
   },
+  {
+    name: 'a point',
+    location: {
+      lng: -74.701,
+      lat: 40,
+    },
+    geometries: [
+      {
+        type: 'sphere',
+        radius: 0,
+        pose: new ViamObject3D(),
+      } as SphereGeometry,
+    ],
+    color: theme.extend.colors.hologram,
+    label: 'transient',
+  },
 ];
 
 const plans: Plans = {


### PR DESCRIPTION
This is the lightest touch way to render a point as a sphere. It does not try to render as an actual point or use sizeAttenuation to scale keep the sphere the same size always.