### PR TITLE
APP-3124: Add hover delay for tooltips

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.70",
+  "version": "0.0.71",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
@@ -3,7 +3,7 @@ import { Tooltip, type FloatingPlacement, type TooltipVisibility } from '$lib';
 
 export let location: FloatingPlacement = 'top';
 export let state: TooltipVisibility | undefined = undefined;
-export let hoverDelayMS: number | undefined = undefined;
+export let hoverDelayMS = 0;
 </script>
 
 <Tooltip

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
@@ -3,11 +3,13 @@ import { Tooltip, type FloatingPlacement, type TooltipVisibility } from '$lib';
 
 export let location: FloatingPlacement = 'top';
 export let state: TooltipVisibility | undefined = undefined;
+export let hoverDelayMs: number | undefined = undefined;
 </script>
 
 <Tooltip
   {location}
   {state}
+  {hoverDelayMs}
   let:tooltipID
 >
   <button

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.svelte
@@ -3,13 +3,13 @@ import { Tooltip, type FloatingPlacement, type TooltipVisibility } from '$lib';
 
 export let location: FloatingPlacement = 'top';
 export let state: TooltipVisibility | undefined = undefined;
-export let hoverDelayMs: number | undefined = undefined;
+export let hoverDelayMS: number | undefined = undefined;
 </script>
 
 <Tooltip
   {location}
   {state}
-  {hoverDelayMs}
+  {hoverDelayMS}
   let:tooltipID
 >
   <button

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
@@ -82,7 +82,7 @@ describe('Tooltip', () => {
   it('shows the tooltip on mouse enter after a delay', async () => {
     const user = userEvent.setup();
 
-    render(Tooltip, { hoverDelayMs: 50 });
+    render(Tooltip, { hoverDelayMS: 50 });
 
     const target = screen.getByTestId('target');
     const tooltip = screen.getByRole('tooltip');

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
@@ -79,6 +79,19 @@ describe('Tooltip', () => {
     expect(tooltip).toHaveClass('invisible');
   });
 
+  it('shows the tooltip on mouse enter after a delay', async () => {
+    const user = userEvent.setup();
+
+    render(Tooltip, { hoverDelayMs: 50 });
+
+    const target = screen.getByTestId('target');
+    const tooltip = screen.getByRole('tooltip');
+
+    await user.hover(target);
+    expect(tooltip).toHaveClass('invisible');
+    await waitFor(() => expect(tooltip).not.toHaveClass('invisible'));
+  });
+
   it('shows/hides the tooltip on keyboard focus/blur', async () => {
     render(Tooltip);
 

--- a/packages/core/src/lib/tooltip/tooltip-container.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-container.svelte
@@ -34,7 +34,11 @@
 <script lang="ts">
 import { provideTooltipContext } from './tooltip-styles';
 
-const { id } = provideTooltipContext();
+export let hoverDelayMs: number | undefined = undefined;
+
+const { id, setHoverDelayMs } = provideTooltipContext();
+
+$: setHoverDelayMs(hoverDelayMs);
 </script>
 
 <slot tooltipID={id} />

--- a/packages/core/src/lib/tooltip/tooltip-container.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-container.svelte
@@ -34,11 +34,11 @@
 <script lang="ts">
 import { provideTooltipContext } from './tooltip-styles';
 
-export let hoverDelayMs: number | undefined = undefined;
+export let hoverDelayMS = 0;
 
-const { id, setHoverDelayMs } = provideTooltipContext();
+const { id, setHoverDelayMS } = provideTooltipContext();
 
-$: setHoverDelayMs(hoverDelayMs);
+$: setHoverDelayMS(hoverDelayMS);
 </script>
 
 <slot tooltipID={id} />

--- a/packages/core/src/lib/tooltip/tooltip-styles.ts
+++ b/packages/core/src/lib/tooltip/tooltip-styles.ts
@@ -7,7 +7,7 @@ import {
   type FloatingPlacement,
 } from '$lib/floating';
 import { uniqueId } from '$lib/unique-id';
-import { noop } from 'lodash';
+import noop from 'lodash/noop';
 
 export type TooltipVisibility = 'invisible' | 'visible';
 

--- a/packages/core/src/lib/tooltip/tooltip.svelte
+++ b/packages/core/src/lib/tooltip/tooltip.svelte
@@ -37,12 +37,22 @@ export let location: FloatingPlacement = 'top';
  */
 export let state: TooltipVisibility | undefined = undefined;
 
+/**
+ * If state is `undefined`, the tooltip only renders on mouse enter and focus.
+ * On mouse enter, this delay is present before the tooltip is shown.
+ * There is no delay for focus.
+ */
+export let hoverDelayMs: number | undefined = undefined;
+
 /** Additional CSS classes to pass to the tooltip text element. */
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
 </script>
 
-<TooltipContainer let:tooltipID>
+<TooltipContainer
+  let:tooltipID
+  {hoverDelayMs}
+>
   <TooltipTarget>
     <slot {tooltipID} />
   </TooltipTarget>

--- a/packages/core/src/lib/tooltip/tooltip.svelte
+++ b/packages/core/src/lib/tooltip/tooltip.svelte
@@ -42,7 +42,7 @@ export let state: TooltipVisibility | undefined = undefined;
  * On mouse enter, this delay is present before the tooltip is shown.
  * There is no delay for focus.
  */
-export let hoverDelayMs: number | undefined = undefined;
+export let hoverDelayMS = 0;
 
 /** Additional CSS classes to pass to the tooltip text element. */
 let extraClasses: cx.Argument = '';
@@ -51,7 +51,7 @@ export { extraClasses as cx };
 
 <TooltipContainer
   let:tooltipID
-  {hoverDelayMs}
+  {hoverDelayMS}
 >
   <TooltipTarget>
     <slot {tooltipID} />

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -443,9 +443,9 @@ const htmlSnippet = `
   <li>Ummm…to eBay?</li>
 </ul>`.trim();
 
-let hoverDelayMs = 1000;
+let hoverDelayMS = 1000;
 const onHoverDelayMsInput = (event: Event) => {
-  hoverDelayMs = Number.parseInt((event.target as HTMLInputElement).value, 10);
+  hoverDelayMS = Number.parseInt((event.target as HTMLInputElement).value, 10);
 };
 </script>
 
@@ -1488,7 +1488,7 @@ const onHoverDelayMsInput = (event: Event) => {
     <div>
       <TooltipContainer
         let:tooltipID
-        {hoverDelayMs}
+        {hoverDelayMS}
       >
         <Label>
           This icon has a tooltip if you're patient.
@@ -1502,8 +1502,8 @@ const onHoverDelayMsInput = (event: Event) => {
           <NumericInput
             slot="input"
             aria-describedby={tooltipID}
-            name="hoverDelayMs"
-            value={hoverDelayMs}
+            name="hoverDelayMS"
+            value={hoverDelayMS}
             on:input={onHoverDelayMsInput}
           />
         </Label>

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -442,6 +442,11 @@ const htmlSnippet = `
   <li>But I know you in the future. I cleaned your poop.</li>
   <li>Ummm…to eBay?</li>
 </ul>`.trim();
+
+let hoverDelayMs = 1000;
+const onHoverDelayMsInput = (event: Event) => {
+  hoverDelayMs = Number.parseInt((event.target as HTMLInputElement).value, 10);
+};
 </script>
 
 <NotificationContainer />
@@ -1477,6 +1482,32 @@ const htmlSnippet = `
           />
         </Label>
         <TooltipText>This is the tooltip text!</TooltipText>
+      </TooltipContainer>
+    </div>
+
+    <div>
+      <TooltipContainer
+        let:tooltipID
+        {hoverDelayMs}
+      >
+        <Label>
+          This icon has a tooltip if you're patient.
+          <TooltipTarget>
+            <Icon
+              tabindex="0"
+              cx="cursor-pointer"
+              name="history"
+            />
+          </TooltipTarget>
+          <NumericInput
+            slot="input"
+            aria-describedby={tooltipID}
+            name="hoverDelayMs"
+            value={hoverDelayMs}
+            on:input={onHoverDelayMsInput}
+          />
+        </Label>
+        <TooltipText>Thanks for waiting!</TooltipText>
       </TooltipContainer>
     </div>
   </div>

--- a/packages/storybook/src/stories/tooltip.mdx
+++ b/packages/storybook/src/stories/tooltip.mdx
@@ -23,11 +23,6 @@ import { Tooltip } from '@viamrobotics/prime-core';
   <Story of={TooltipStories.CustomTarget} />
 </Canvas>
 
-{/* TODO (APP-2290): Add this when Icon is added */}
-{/* <Canvas> */}
-{/* <Story name='With Icon'> */}
-{/* {() => ({ */}
-{/* Component: WithIcon, */}
-{/* })} */}
-{/* </Story> */}
-{/* </Canvas> */}
+<Canvas>
+  <Story of={TooltipStories.HoverDelay} />
+</Canvas>

--- a/packages/storybook/src/stories/tooltip.stories.svelte
+++ b/packages/storybook/src/stories/tooltip.stories.svelte
@@ -59,7 +59,7 @@ import {
   <div class="flex pt-5">
     <Tooltip
       let:tooltipID
-      hoverDelayMs={1000}
+      hoverDelayMS={1000}
     >
       <p aria-describedby={tooltipID}>
         This element has a tooltip that shows up if you're patient.

--- a/packages/storybook/src/stories/tooltip.stories.svelte
+++ b/packages/storybook/src/stories/tooltip.stories.svelte
@@ -54,3 +54,17 @@ import {
     </TooltipContainer>
   </div>
 </Story>
+
+<Story name="Hover Delay">
+  <div class="flex pt-5">
+    <Tooltip
+      let:tooltipID
+      hoverDelayMs={1000}
+    >
+      <p aria-describedby={tooltipID}>
+        This element has a tooltip that shows up if you're patient.
+      </p>
+      <p slot="description">Thanks for waiting!</p>
+    </Tooltip>
+  </div>
+</Story>


### PR DESCRIPTION
Per the [designs for APP-3124](https://www.figma.com/file/GSi2nRrsKHQnP2uYNx5XMK/Make-UI-Not-Shitty-II?type=design&node-id=3100-16026&mode=design&t=MNU0aepvDubaCdJ1-11), some tooltips should only show after 1s of hovering.

## Change log

- Add `hoverDelayMS` prop to `Tooltip` and `TooltipContainer`
- Add `hoverDelayMS` writable to tooltip context, and update `isVisible` derived store to set after timeout
- Add test
- Add example to dev environment
- Add example to storybook

![tooltip-hover-delay](https://github.com/viamrobotics/prime/assets/5910938/ab8ece29-c457-4ceb-a430-2c73b592b20c)
