### PR TITLE
APP-2198: Bump prime-core version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.72",
+  "version": "0.0.73",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
The purpose of this PR is to bump the prime-core version from `0.0.72` to `0.0.73`