### PR TITLE
APP-2198: Addressing stylistic issues in toast

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.79",
+  "version": "0.0.80",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -50,6 +50,7 @@ export {
 
 export {
   ToastContainer,
+  ToastBanner,
   provideToast,
   useToast,
   ToastVariant,

--- a/packages/core/src/lib/toast/context.ts
+++ b/packages/core/src/lib/toast/context.ts
@@ -62,7 +62,7 @@ export const createToastContext = (): ToastContext => {
     const pause = () => setPaused(id, true);
     const resume = () => setPaused(id, false);
     const dismiss = () => remove(id);
-    const { progress, unsubscribe } = pausableProgress({
+    const { unsubscribe } = pausableProgress({
       isPaused,
       totalDuration: ToastDuration,
       onComplete: dismiss,
@@ -70,7 +70,6 @@ export const createToastContext = (): ToastContext => {
 
     const toast = {
       id,
-      progress,
       pause,
       resume,
       dismiss,

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -2,7 +2,7 @@
 
 <script lang="ts">
 import cx from 'classnames';
-import { Button, Icon } from '$lib';
+import { Icon, IconButton } from '$lib';
 import { iconName, iconClasses } from './variants';
 
 /** The message displayed on the toast */
@@ -10,7 +10,7 @@ export let message: string;
 /** Function called when the close button is clicked */
 export let dismiss: () => void;
 /** The action performed on the button */
-export let action: { text: string; handler: () => void } | undefined =
+export let action: { text: string; handler: () => unknown } | undefined =
   undefined;
 
 /** Additional CSS classes to pass to the banner. */
@@ -37,20 +37,21 @@ export { extraClasses as cx };
     {message}
   </div>
 
-  {#if action}
-    <button
-      on:click={action.handler}
-      aria-label="Perform action"
-    >
-      <span class="text-sm font-medium hover:underline">{action.text}</span>
-    </button>
-  {/if}
-  <Button
-    variant="ghost"
-    cx="text-gray-7"
-    aria-label="Dismiss toast"
-    on:click={dismiss}
-  >
-    <Icon name="close" />
-  </Button>
+  <div class="flex gap-1">
+    {#if action}
+      <button
+        type="button"
+        on:click={action.handler}
+        aria-label="Perform action"
+      >
+        <span class="text-sm font-medium hover:underline">{action.text}</span>
+      </button>
+    {/if}
+    <IconButton
+      cx="text-gray-7"
+      label="Dismiss toast"
+      icon="close"
+      on:click={dismiss}
+    />
+  </div>
 </div>

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -20,7 +20,7 @@ export { extraClasses as cx };
 
 <div
   class={cx(
-    'relative flex h-10 w-auto max-w-[480px] items-center border bg-medium pl-3 pr-1 text-sm',
+    'relative flex h-10 w-max max-w-[480px] items-center border bg-medium pl-3 pr-1 text-sm',
     extraClasses
   )}
 >
@@ -34,7 +34,7 @@ export { extraClasses as cx };
       aria-label="success"
     />
 
-    {message}
+    <p class="truncate">{message}</p>
   </div>
 
   <div class="flex gap-1">

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -20,7 +20,7 @@ export { extraClasses as cx };
 
 <div
   class={cx(
-    'relative flex w-auto items-center gap-2 border bg-medium p-2 text-sm',
+    'relative flex w-auto items-center gap-2 border bg-medium p-1 text-sm',
     extraClasses
   )}
 >

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -10,7 +10,7 @@ export let message: string;
 /** Function called when the close button is clicked */
 export let dismiss: () => void;
 /** The action performed on the button */
-export let action: { text: string; handler: () => unknown } | undefined =
+export let action: { text: string; handler: () => void } | undefined =
   undefined;
 
 /** Additional CSS classes to pass to the banner. */
@@ -20,11 +20,11 @@ export { extraClasses as cx };
 
 <div
   class={cx(
-    'relative flex w-auto items-center gap-2 border bg-medium p-1 text-sm',
+    'relative flex h-10 w-auto max-w-[480px] items-center border bg-medium pl-3 pr-1 text-sm',
     extraClasses
   )}
 >
-  <div class="w-[18px]">
+  <div class="mr-4 flex gap-2">
     <Icon
       size="lg"
       name={iconName}
@@ -33,9 +33,9 @@ export { extraClasses as cx };
       aria-hidden={false}
       aria-label="success"
     />
-  </div>
 
-  <div class="mr-auto">{message}</div>
+    {message}
+  </div>
 
   {#if action}
     <button

--- a/packages/core/src/lib/toast/toast-container.svelte
+++ b/packages/core/src/lib/toast/toast-container.svelte
@@ -11,10 +11,11 @@ It needs access to context from `provideToast`, which should also
 be added to the root layout component.
 -->
 <script lang="ts">
-import { fade, fly } from 'svelte/transition';
+import { fly, fade } from 'svelte/transition';
 
 import { useToastState } from './context';
 import ToastBanner from './toast-banner.svelte';
+import { flip } from 'svelte/animate';
 
 const { toasts, pageIsVisible } = useToastState();
 let visibilityState: DocumentVisibilityState;
@@ -27,13 +28,14 @@ $: pageIsVisible.set(visibilityState === 'visible');
 <div
   role="status"
   aria-label="Toasts"
-  class="pointer-events-auto fixed bottom-0 left-1/2 top-auto z-max -translate-x-1/2 transform overflow-hidden pb-6"
+  class="fixed bottom-0 left-1/2 top-auto z-max -translate-x-1/2 transform pb-6"
 >
-  <ul class="flex flex-col items-center gap-2">
+  <ul class="flex flex-col items-center gap-3">
     {#each $toasts as { id, pause, resume, ...toast } (id)}
       <li
-        in:fly={{ y: 256 }}
-        out:fade={{ duration: 400, delay: 400 }}
+        in:fly={{ y: 64 }}
+        out:fade
+        animate:flip={{ duration: 200 }}
         on:mouseenter={pause}
         on:mouseleave={resume}
       >

--- a/packages/core/src/lib/toast/toast-container.svelte
+++ b/packages/core/src/lib/toast/toast-container.svelte
@@ -12,7 +12,6 @@ be added to the root layout component.
 -->
 <script lang="ts">
 import { fade, fly } from 'svelte/transition';
-import { flip } from 'svelte/animate';
 
 import { useToastState } from './context';
 import ToastBanner from './toast-banner.svelte';
@@ -28,14 +27,13 @@ $: pageIsVisible.set(visibilityState === 'visible');
 <div
   role="status"
   aria-label="Toasts"
-  class="pointer-events-auto fixed bottom-0 left-1/2 top-auto z-max -translate-x-1/2 transform overflow-hidden p-1.5"
+  class="pointer-events-auto fixed bottom-0 left-1/2 top-auto z-max -translate-x-1/2 transform overflow-hidden pb-6"
 >
   <ul class="flex flex-col items-center gap-2">
     {#each $toasts as { id, pause, resume, ...toast } (id)}
       <li
         in:fly={{ y: 256 }}
-        out:fade
-        animate:flip={{ duration: 200 }}
+        out:fade={{ duration: 400, delay: 400 }}
         on:mouseenter={pause}
         on:mouseleave={resume}
       >

--- a/packages/core/src/lib/toast/toast-container.svelte
+++ b/packages/core/src/lib/toast/toast-container.svelte
@@ -11,11 +11,11 @@ It needs access to context from `provideToast`, which should also
 be added to the root layout component.
 -->
 <script lang="ts">
-import { fly, fade } from 'svelte/transition';
+import { fade, fly } from 'svelte/transition';
+import { flip } from 'svelte/animate';
 
 import { useToastState } from './context';
 import ToastBanner from './toast-banner.svelte';
-import { flip } from 'svelte/animate';
 
 const { toasts, pageIsVisible } = useToastState();
 let visibilityState: DocumentVisibilityState;

--- a/packages/storybook/src/stories/toast-banner.mdx
+++ b/packages/storybook/src/stories/toast-banner.mdx
@@ -1,0 +1,20 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import * as ToastBannerStories from './toast-banner.stories.svelte';
+
+<Meta title='Elements/ToastBanner' />
+
+# ToastBanner
+
+Toast Banner message of type success.
+
+```ts
+import { ToastBanner } from '@viamrobotics/prime-core';
+```
+
+<Canvas>
+  <Story of={ToastBannerStories.Success} />
+</Canvas>
+
+<Canvas>
+  <Story of={ToastBannerStories.SuccessWithEmphasizedAction} />
+</Canvas>

--- a/packages/storybook/src/stories/toast-banner.stories.svelte
+++ b/packages/storybook/src/stories/toast-banner.stories.svelte
@@ -18,7 +18,9 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 <Story name="SuccessWithEmphasizedAction">
   <ToastBanner
     message="Success message"
-    dismiss={() => {}}
+    dismiss={() => {
+      console.log('Clicked close button')
+    }}
     action={{
       text: 'action',
       handler: () => {

--- a/packages/storybook/src/stories/toast-banner.stories.svelte
+++ b/packages/storybook/src/stories/toast-banner.stories.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+import { Meta, Story } from '@storybook/addon-svelte-csf';
+import { ToastBanner } from '@viamrobotics/prime-core';
+</script>
+
+<Meta title="Elements/ToastBanner" />
+
+<Story name="Success">
+  <ToastBanner
+    message="Success message"
+    dismiss={() => {
+      console.log('Clicked close button');
+    }}
+    cx="max-w-[240px]"
+  />
+</Story>
+
+<Story name="SuccessWithEmphasizedAction">
+  <ToastBanner
+    message="Success message"
+    dismiss={() => {}}
+    action={{
+      text: 'action',
+      handler: () => {
+        console.log('Clicked action');
+      },
+    }}
+    cx="max-w-[280px]"
+  />
+</Story>

--- a/packages/storybook/src/stories/toast-banner.stories.svelte
+++ b/packages/storybook/src/stories/toast-banner.stories.svelte
@@ -19,7 +19,7 @@ import { ToastBanner } from '@viamrobotics/prime-core';
   <ToastBanner
     message="Success message"
     dismiss={() => {
-      console.log('Clicked close button')
+      console.log('Clicked close button');
     }}
     action={{
       text: 'action',


### PR DESCRIPTION
In this PR, I made the following changes to the toast ui element:

- Increased the bottom margin of the toast to `24px`
- Fixed the fade out effect by adding `delay` and `duration`
- Fixed the internal padding of the toast to match the figma designs.

## Visuals

https://github.com/viamrobotics/prime/assets/48206838/4ee2b2f9-8413-4eb9-8399-8946e45416f0


