### PR TITLE
APP-3126: fix searchable select value and focus issues

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.76",
+  "version": "0.0.77",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -81,6 +81,7 @@ export {
   type TooltipVisibility,
 } from './tooltip';
 
+export * from './keyboard';
 export { useTimeout } from './use-timeout';
 export { uniqueId } from './unique-id';
 export { default as VectorInput } from './vector-input.svelte';

--- a/packages/core/src/lib/keyboard.ts
+++ b/packages/core/src/lib/keyboard.ts
@@ -1,0 +1,26 @@
+export type KeyMap = Partial<Record<string, KeyEventHandler | KeyOptions>>;
+
+export type KeyEventHandler = (event: KeyboardEvent) => unknown;
+
+export interface KeyOptions {
+  handler: KeyEventHandler;
+  preventDefault?: boolean;
+}
+
+export const createHandleKey = (keyMap: KeyMap) => {
+  return (event: KeyboardEvent): void => {
+    const options = keyMap[event.key];
+    const handler = typeof options === 'function' ? options : options?.handler;
+    const preventDefault =
+      typeof options === 'object' ? options.preventDefault : true;
+
+    if (typeof handler === 'function') {
+      handler(event);
+
+      if (preventDefault) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+    }
+  };
+};

--- a/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
@@ -275,7 +275,7 @@ describe('combobox list', () => {
     expect(options).toHaveLength(3);
     expect(options[0]).toHaveAccessibleName('hello from');
     expect(options[1]).toHaveAccessibleName('the other side');
-    expect(options[2]).toHaveAccessibleName('other: hello');
+    expect(options[2]).toHaveAccessibleName('hello');
     expect(options[2]).toHaveAttribute('aria-selected', 'false');
   });
 
@@ -287,7 +287,7 @@ describe('combobox list', () => {
     await user.type(search, 'asdf');
     const { options } = getResults();
 
-    expect(options[2]).toHaveAccessibleName('other: asdf');
+    expect(options[2]).toHaveAccessibleName('asdf');
     expect(options[2]).toHaveAttribute('aria-selected', 'true');
     expect(search).toHaveAttribute('aria-activedescendant', options[2]?.id);
   });
@@ -331,6 +331,17 @@ describe('combobox list', () => {
     const { options } = getResults();
 
     expect(options).toHaveLength(3);
+  });
+
+  it('adds a prefix to the "other" option display text', async () => {
+    const user = userEvent.setup();
+    renderSubject({ otherOptionPrefix: 'You said:' });
+
+    const { search } = getResults();
+    await user.type(search, 'hello');
+    const { options } = getResults();
+
+    expect(options[2]).toHaveAccessibleName('You said: hello');
   });
 
   it('empties input value if closed and exclusive', async () => {

--- a/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
@@ -308,8 +308,6 @@ describe('combobox list', () => {
     const { options } = getResults();
 
     expect(options).toHaveLength(2);
-    expect(options[0]).toHaveAccessibleName('hello from');
-    expect(options[1]).toHaveAccessibleName('the other side');
   });
 
   it('empties input value if closed and exclusive', async () => {

--- a/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
@@ -1,282 +1,442 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
-import SearchableSelect from '../searchable-select.svelte';
-import { cxTestArguments, cxTestResults } from '$lib/__tests__/cx-test';
+import { describe, expect, it, vi } from 'vitest';
+import { act, render, screen, within } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'svelte';
 
-describe('SearchableSelect', () => {
-  const options = [
-    'First Option',
-    'Option 2',
-    'C.) Option',
-    'Something Else',
-    'With A Whole Lot Of Parts',
-  ];
+import { SearchableSelect as Subject, InputStates } from '$lib';
 
-  const common = { placeholder: 'Select an option', options };
+const onChange = vi.fn();
+const onFocus = vi.fn();
+const onBlur = vi.fn();
 
-  it('Renders the select input', () => {
-    render(SearchableSelect, common);
+const renderSubject = (props: Partial<ComponentProps<Subject>> = {}) => {
+  return render(Subject, {
+    options: ['hello from', 'the other side'],
+    onChange,
+    onFocus,
+    onBlur,
+    ...props,
+  });
+};
 
-    const select = screen.getByPlaceholderText('Select an option');
+const getResults = (): {
+  search: HTMLElement;
+  button: HTMLElement;
+  list: HTMLElement;
+  options: HTMLElement[];
+} => {
+  const search = screen.getByRole('combobox');
+  const button = screen.getByRole('button');
+  const list = screen.getByRole('listbox');
+  const options = within(list).queryAllByRole('option');
 
-    expect(select).toHaveClass(
-      'h-7.5 w-full grow appearance-none border py-1.5 pl-2 pr-1 text-xs leading-tight outline-none'
-    );
+  return { search, button, list, options };
+};
+
+describe('combobox list', () => {
+  it('controls a listbox', () => {
+    renderSubject();
+
+    const { search, button, list } = getResults();
+
+    expect(list).toHaveAttribute('id', expect.any(String));
+    expect(button).toHaveAttribute('aria-controls', list.id);
+    expect(search).toHaveAttribute('aria-controls', list.id);
+    expect(search).toHaveAttribute('aria-autocomplete', 'list');
   });
 
-  it('Renders the select as disabled', () => {
-    render(SearchableSelect, {
-      ...common,
+  it('has a placeholder', () => {
+    renderSubject({ placeholder: "It's me" });
+
+    expect(getResults().search).toBe(screen.getByPlaceholderText("It's me"));
+  });
+
+  it.each([
+    {
+      state: InputStates.NONE,
+      disabled: false,
+      classNames: ['border-light', 'bg-white', 'focus:border-gray-9'],
+    },
+    {
+      state: InputStates.WARN,
+      disabled: false,
+      classNames: [
+        'border-warning-bright',
+        'bg-white',
+        'focus:outline-warning-bright',
+      ],
+    },
+    {
+      state: InputStates.ERROR,
+      disabled: false,
+      classNames: [
+        'border-danger-dark',
+        'bg-white',
+        'focus:outline-danger-dark',
+      ],
+    },
+    {
+      state: InputStates.NONE,
       disabled: true,
-    });
+      classNames: [
+        'cursor-not-allowed',
+        'border-disabled-light',
+        'bg-disabled-light',
+        'focus:border-disabled-dark',
+      ],
+    },
+  ])(
+    'displays state=$state, disabled=$disabled',
+    ({ state, disabled, classNames }) => {
+      renderSubject({ state, disabled });
 
-    const select = screen.getByPlaceholderText('Select an option');
+      expect(getResults().search).toHaveClass(...classNames);
+    }
+  );
 
-    expect(select).toHaveClass(
-      'bg-disabled-light text-disabled-dark border-disabled-light cursor-not-allowed'
-    );
+  it('expands the listbox on focus', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    expect(select).toHaveAttribute('aria-disabled', 'true');
+    const { search, button, list } = getResults();
+
+    expect(list).toHaveClass('hidden');
+    expect(search).toHaveAttribute('aria-expanded', 'false');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    await user.keyboard('{Tab}');
+
+    expect(onFocus).toHaveBeenCalledOnce();
+    expect(search).toHaveFocus();
+    expect(list).not.toHaveClass('hidden');
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(search).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('Renders the select in the warn state', () => {
-    render(SearchableSelect, {
-      ...common,
-      state: 'warn',
-    });
+  it('expands the listbox on button click', async () => {
+    renderSubject();
 
-    const select = screen.getByPlaceholderText('Select an option');
+    const { search, button } = getResults();
 
-    expect(select).toHaveClass(
-      'border-warning-bright focus:outline-warning-bright focus:outline-[1.5px] focus:-outline-offset-1'
-    );
+    // TODO(mc, 2024-02-03): replace button.click with userEvent
+    // https://github.com/testing-library/user-event/issues/1119
+    await act(() => button.click());
+
+    expect(search).toHaveFocus();
+    expect(search).toHaveAttribute('aria-expanded', 'true');
   });
 
-  it('Renders the select in the error state', () => {
-    render(SearchableSelect, {
-      ...common,
-      state: 'error',
-    });
+  it('does not expand the listbox if disabled', async () => {
+    const user = userEvent.setup();
+    renderSubject({ disabled: true });
 
-    const select = screen.getByPlaceholderText('Select an option');
+    const { search } = getResults();
+    await user.keyboard('{Tab}');
 
-    expect(select).toHaveClass(
-      'border-danger-dark focus:outline-danger-dark focus:outline-[1.5px] focus:-outline-offset-1'
-    );
+    expect(onFocus).toHaveBeenCalledOnce();
+    expect(search).toHaveFocus();
+    expect(search).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('Renders the select heading', () => {
-    render(SearchableSelect, {
-      ...common,
-      heading: 'Test Heading',
-    });
+  it('closes the listbox if no options', async () => {
+    const user = userEvent.setup();
+    renderSubject({ exclusive: true, sort: 'reduce' });
 
-    const heading = screen.getByText('Test Heading');
+    const { search } = getResults();
+    await user.type(search, 'asdf');
 
-    expect(heading).toHaveClass(
-      'text-default flex flex-wrap py-1 pl-2 text-xs'
-    );
+    expect(search).toHaveFocus();
+    expect(search).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('Renders the select button', async () => {
-    const onButtonClick = vi.fn();
-    const { component } = render(SearchableSelect, {
-      ...common,
-      button: { text: 'Test Button', icon: 'alert' },
-    });
+  it('closes the listbox on second button click', async () => {
+    renderSubject();
 
-    component.$on('buttonclick', onButtonClick);
+    const { search, button } = getResults();
 
-    const button = screen.getByText('Test Button');
+    // TODO(mc, 2024-02-03): replace button.click with userEvent
+    // https://github.com/testing-library/user-event/issues/1119
+    await act(() => button.click());
+    await act(() => button.click());
 
-    expect(button).toHaveClass('pl-1.5');
-    expect(button.parentElement).toHaveClass(
-      'hover:bg-light border-light flex h-7.5 w-full items-center border-t px-2 py-1 text-xs'
-    );
-
-    await userEvent.click(button);
-
-    expect(onButtonClick).toHaveBeenCalled();
+    expect(search).toHaveFocus();
+    expect(search).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('Sorts results with a match at the start of a word', async () => {
-    render(SearchableSelect, common);
+  it('collapses the listbox on blur', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
-    const menu = screen.getByRole('menu');
+    const { search } = getResults();
 
-    select.focus();
-    await userEvent.type(select, 'C.)');
+    await user.keyboard('{Tab}{Tab}');
 
-    expect(menu.children[0]?.textContent?.trim()).toBe('C.)  Option');
-
-    await userEvent.type(select, 'Opt');
-
-    expect(menu.children[0]?.textContent?.trim()).toBe('First Option');
+    expect(onBlur).toHaveBeenCalledOnce();
+    expect(search).not.toHaveFocus();
+    expect(search).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('Sorts results with a match below matches at a start of the word', async () => {
-    render(SearchableSelect, common);
+  it('has options', () => {
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
-    const menu = screen.getByRole('menu');
+    const { search, options } = getResults();
 
-    select.focus();
-    await userEvent.type(select, 'l');
-
-    expect(menu.children[0]?.textContent?.trim()).toBe(
-      'With A Whole  L ot Of Parts'
-    );
-
-    expect(menu.children[1]?.textContent?.trim()).toBe('Something E l se');
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveAccessibleName('hello from');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAccessibleName('the other side');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+    expect(search).not.toHaveAttribute('aria-activedescendant');
   });
 
-  it('Filters out options without a match when reduce is true', async () => {
-    render(SearchableSelect, { ...common, sort: 'reduce' });
+  it('selects a clicked option', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
-    const menu = screen.getByRole('menu');
+    const { search, options } = getResults();
 
-    select.focus();
-    await userEvent.type(select, 'C.)');
+    await user.click(search);
+    await user.click(options[0]!);
 
-    expect(menu.children[0]?.textContent?.trim()).toBe('C.)  Option');
-    expect(menu.children.length).toBe(1);
+    expect(onChange).toHaveBeenCalledWith('hello from');
+    expect(search).toHaveValue('hello from');
+    expect(search).toHaveAttribute('aria-expanded', 'false');
+    expect(search).not.toHaveAttribute('aria-activedescendant');
   });
 
-  it('Just highlights but does not filter or sort when sort is off', async () => {
-    render(SearchableSelect, { ...common, sort: 'off' });
+  it('auto-selects search result on Enter', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
-    const menu = screen.getByRole('menu');
+    const { search } = getResults();
+    await user.type(search, 'the other');
+    const { options } = getResults();
 
-    select.focus();
-    await userEvent.type(select, 'C.)');
+    expect(options[0]).toHaveAccessibleName('the other side');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    expect(options[0]).toHaveAttribute('id', expect.any(String));
+    expect(options[1]).toHaveAccessibleName('hello from');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).not.toHaveAttribute('id', options[0]?.id);
+    expect(search).toHaveAttribute('aria-activedescendant', options[0]?.id);
 
-    expect(menu.children[0]?.textContent?.trim()).toBe('First Option');
-    expect(menu.children[1]?.textContent?.trim()).toBe('Option 2');
-    expect(menu.children[2]?.textContent?.trim()).toBe('C.)  Option');
-    expect(menu.children.length).toBe(5);
+    await user.keyboard('{Enter}');
+
+    expect(onChange).toHaveBeenCalledWith('the other side');
+    expect(search).toHaveValue('the other side');
+    expect(search).toHaveAttribute('aria-expanded', 'false');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+    expect(search).not.toHaveAttribute('aria-activedescendant');
   });
 
-  it('Selects an option with click', async () => {
-    render(SearchableSelect, common);
+  it('auto-selects search result on blur', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
+    const { search } = getResults();
+    await user.type(search, 'the other');
+    await user.keyboard('{Tab}');
 
-    select.focus();
-    await userEvent.click(screen.getAllByRole('menuitem')[2]!);
-
-    expect(select.value).toBe('C.) Option');
+    expect(onChange).toHaveBeenCalledWith('the other side');
   });
 
-  it('Navigates to and selects an option with enter', async () => {
-    render(SearchableSelect, common);
+  it('keeps input value if menu closed on blur', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
+    const { search } = getResults();
+    await user.type(search, 'the other');
+    await user.keyboard('{Escape}{Tab}');
 
-    select.focus();
-    await userEvent.keyboard('[ArrowDown]');
-    await userEvent.keyboard('[ArrowDown]');
-    await userEvent.keyboard('[ArrowDown]');
-    await userEvent.keyboard('[Enter]');
-
-    expect(select.value).toBe('C.) Option');
+    expect(onChange).toHaveBeenCalledWith('the other');
   });
 
-  it('Navigates through the list', async () => {
-    render(SearchableSelect, common);
+  it('has an "other" option when not exclusive', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
-    const menuItems = screen.getAllByRole('menuitem');
+    const { search } = getResults();
+    await user.type(search, 'hello');
+    const { options } = getResults();
 
-    select.focus();
-    await userEvent.keyboard('[ArrowDown]');
-
-    expect(menuItems[0]).toHaveClass('bg-light');
-
-    await userEvent.keyboard('[ArrowDown]');
-    await userEvent.keyboard('[ArrowDown]');
-
-    expect(menuItems[2]).toHaveClass('bg-light');
-
-    await userEvent.keyboard('[ArrowDown]');
-    await userEvent.keyboard('[ArrowDown]');
-
-    expect(menuItems[4]).toHaveClass('bg-light');
-
-    await userEvent.keyboard('[ArrowDown]');
-
-    expect(menuItems[0]).toHaveClass('bg-light');
-
-    await userEvent.keyboard('[ArrowUp]');
-
-    expect(menuItems[4]).toHaveClass('bg-light');
-
-    await userEvent.keyboard('[ArrowUp]');
-    await userEvent.keyboard('[ArrowUp]');
-    await userEvent.keyboard('[Enter]');
-
-    expect(select.value).toBe('C.) Option');
+    expect(options).toHaveLength(3);
+    expect(options[0]).toHaveAccessibleName('hello from');
+    expect(options[1]).toHaveAccessibleName('the other side');
+    expect(options[2]).toHaveAccessibleName('other: hello');
+    expect(options[2]).toHaveAttribute('aria-selected', 'false');
   });
 
-  it('Closes the menu on escape', async () => {
-    render(SearchableSelect, common);
+  it('sets an "other" option as active when no search matches', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
-    const menu = screen.getByRole('menu');
-    const menuItems = screen.getAllByRole('menuitem');
+    const { search } = getResults();
+    await user.type(search, 'asdf');
+    const { options } = getResults();
 
-    expect(menu.parentElement).toHaveClass('invisible');
-
-    select.focus();
-    await userEvent.keyboard('[ArrowDown]');
-
-    expect(menuItems[0]).toHaveClass('bg-light');
-
-    await userEvent.keyboard('[Escape]');
-
-    expect(menu.parentElement).toHaveClass('invisible');
+    expect(options[2]).toHaveAccessibleName('other: asdf');
+    expect(options[2]).toHaveAttribute('aria-selected', 'true');
+    expect(search).toHaveAttribute('aria-activedescendant', options[2]?.id);
   });
 
-  it('Closes the menu on tab', async () => {
-    render(SearchableSelect, common);
+  it('has no "other" option when value empty', () => {
+    renderSubject();
 
-    const select: HTMLInputElement =
-      screen.getByPlaceholderText('Select an option');
-    const menu = screen.getByRole('menu');
-    const menuItems = screen.getAllByRole('menuitem');
+    const { options } = getResults();
 
-    expect(menu.parentElement).toHaveClass('invisible');
-
-    select.focus();
-    await userEvent.keyboard('[ArrowDown]');
-
-    expect(menuItems[0]).toHaveClass('bg-light');
-
-    await userEvent.keyboard('[Tab]');
-
-    expect(menu.parentElement).toHaveClass('invisible');
+    expect(options).toHaveLength(2);
   });
 
-  it('Renders with the passed cx classes', () => {
-    render(SearchableSelect, {
-      ...common,
-      cx: cxTestArguments,
-    });
+  it('has no "other" option when value matches', async () => {
+    const user = userEvent.setup();
+    renderSubject();
 
-    expect(
-      screen.getByPlaceholderText('Select an option').parentElement
-        ?.parentElement
-    ).toHaveClass(cxTestResults);
+    const { search } = getResults();
+    await user.type(search, 'hello from');
+    const { options } = getResults();
+
+    expect(options).toHaveLength(2);
+  });
+
+  it('has no "other" option when exclusive', async () => {
+    const user = userEvent.setup();
+    renderSubject({ exclusive: true });
+
+    const { search } = getResults();
+    await user.type(search, 'hello');
+    const { options } = getResults();
+
+    expect(options).toHaveLength(2);
+    expect(options[0]).toHaveAccessibleName('hello from');
+    expect(options[1]).toHaveAccessibleName('the other side');
+  });
+
+  it('empties input value if closed and exclusive', async () => {
+    const user = userEvent.setup();
+    renderSubject({ exclusive: true });
+
+    const { search } = getResults();
+    await user.type(search, 'hello');
+    await user.keyboard('{Escape}{Tab}');
+
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('closes listbox on escape', async () => {
+    const user = userEvent.setup();
+    renderSubject();
+
+    const { search } = getResults();
+    await user.type(search, 'the other');
+    await user.keyboard('{Escape}');
+
+    expect(search).toHaveAttribute('aria-expanded', 'false');
+    expect(search).toHaveValue('the other');
+  });
+
+  it('resets input after closing on escape', async () => {
+    const user = userEvent.setup();
+    renderSubject();
+
+    const { search } = getResults();
+
+    await user.type(search, 'the other');
+    await user.keyboard('{Escape}{Escape}');
+
+    expect(search).toHaveValue('');
+  });
+
+  it('reopens listbox on more typing', async () => {
+    const user = userEvent.setup();
+    renderSubject();
+
+    const { search, options } = getResults();
+
+    await user.type(search, 'the other');
+    await user.keyboard('{Escape} side');
+
+    expect(search).toHaveAttribute('aria-expanded', 'true');
+    expect(search).toHaveAttribute('aria-activedescendant', options[1]?.id);
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('moves visual focus to options on arrow keys', async () => {
+    const user = userEvent.setup();
+    renderSubject();
+
+    const { search, options } = getResults();
+    await user.keyboard('{Tab}');
+
+    await user.keyboard('{ArrowDown}');
+    expect(search).toHaveAttribute('aria-activedescendant', options[0]?.id);
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+
+    await user.keyboard('{ArrowDown}');
+    expect(search).toHaveAttribute('aria-activedescendant', options[1]?.id);
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowDown}');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowUp}');
+    expect(options[1]).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowUp}');
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('sets cursor with home and end', async () => {
+    const user = userEvent.setup();
+    renderSubject();
+
+    const { search } = getResults();
+    await user.type(search, 'e');
+    await user.keyboard('{Home}h');
+
+    expect(search).toHaveValue('he');
+
+    await user.keyboard('{End}llo');
+    expect(search).toHaveValue('hello');
+  });
+
+  it('opens listbox with alt+down arrow without changing selected state', async () => {
+    const user = userEvent.setup();
+    renderSubject();
+
+    const { search, options } = getResults();
+    await user.keyboard('{Tab}{Alt>}{ArrowDown}{/Alt}');
+
+    expect(search).toHaveAttribute('aria-expanded', 'true');
+    expect(options[0]).toHaveAttribute('aria-selected', 'false');
+    expect(options[1]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it.each(['{Home}', '{End}', '{ArrowRight}', '{ArrowLeft}'])(
+    'moves visual focus to input and resets highlight with %s',
+    async (key) => {
+      const user = userEvent.setup();
+      renderSubject();
+
+      const { search, options } = getResults();
+      await user.type(search, 'hello');
+      await user.keyboard(`{ArrowDown}${key}`);
+
+      expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    }
+  );
+
+  it('resets selected item on close', async () => {
+    const user = userEvent.setup();
+    renderSubject();
+
+    const { search, options } = getResults();
+    await user.type(search, 'hello');
+    await user.keyboard('{Escape}{ArrowDown}');
+
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -1,241 +1,245 @@
 <!--
 @component
 
-For selecting from a list of options.
+Select an option from a list, with search
 
 ```svelte
 <SearchableSelect
   options={["Option 1", "Option 2", "Option 3"]}
-  on:input={onSelect}
+  bind:value
 />
 ```
 -->
-<svelte:options immutable />
-
 <script lang="ts">
 import cx from 'classnames';
-import { uniqueId } from '$lib/unique-id';
-import { clickOutside } from '$lib/click-outside';
-import type { IconName } from '$lib/icon';
+import { Floating } from '$lib/floating';
+import { Icon } from '$lib/icon';
 import { InputStates, type InputState } from '$lib/input';
+import { createHandleKey } from '$lib/keyboard';
+import { uniqueId } from '$lib/unique-id';
 
-import { selectControls } from './controls';
-import { createSearchableSelectDispatcher } from './dispatcher';
 import { SortOptions, getSearchResults, type SortOption } from './search';
 import SelectInput from './select-input.svelte';
-import SelectMenuButton from './select-menu-button.svelte';
-import SelectMenu from './select-menu.svelte';
 
 /** The options the user should be allowed to search and select from. */
-export let options: string[] = [];
+export let options: string[];
 
 /** The value of the search input or the currently selected option, if any. */
-export let value: string | undefined = undefined;
+export let value = '';
 
-/** Whether or not the select should be rendered as disabled and be non-operable. */
+/** The placeholder of the input. */
+export let placeholder = '';
+
+/** Value must be constrained to `options` on change. */
+export let exclusive = false;
+
+/** Input is disabled. */
 export let disabled = false;
 
 /** The state of the select (info, warn, error, success), if any. */
 export let state: InputState = InputStates.NONE;
 
-/**
- * How to handle sorting for the select:
- * - `default` will sort results with a match at the beginning of a word first,
- * followed by any other results with match, followed by results with no match.
- * - 'reduce' will do the same as `default` but will filter our results with
- * no match.
- * - `off` will apply no sorting or filtering.
- */
+/** Option sorting behavior. */
 export let sort: SortOption = SortOptions.DEFAULT;
 
-/**
- * An optional call-to-action button to render at the bottom of the select menu
- * that will emit the `buttonclick` event when actioned.
- */
-export let button: { text: string; icon: IconName } | undefined = undefined;
+/** Error message ID, if any. */
+export let errorID = '';
 
-/** An optional heading to render at the top of the select menu. */
-export let heading = '';
+/** Notify the parent of a value change, after Enter key or blur. */
+export let onChange: ((value: string) => unknown) | undefined = undefined;
+
+/** Notify the parent of focus. */
+export let onFocus: ((event: FocusEvent) => unknown) | undefined = undefined;
+
+/** Notify the parent of blur. */
+export let onBlur: ((event: FocusEvent) => unknown) | undefined = undefined;
 
 /** Additional CSS classes to pass to the input container. */
-let extraClasses: cx.Argument = '';
-export { extraClasses as cx };
+let inputCx: cx.Argument = '';
+export { inputCx as cx };
 
-const dispatch = createSearchableSelectDispatcher<{
-  /** When an option is selected, emit the value. */
-  input: string | undefined;
-}>();
+const LIST_ID = uniqueId('combobox-list');
+const SELECTED_ID = uniqueId('combobox-list-selected-item');
+const CLOSED = 'closed';
+const FOCUS_SEARCH = 'focus-search';
+const FOCUS_ITEM = 'focus-item';
 
-const menuId = uniqueId('searchable-select');
-let menu: HTMLUListElement;
+type MenuState = typeof CLOSED | typeof FOCUS_SEARCH | typeof FOCUS_ITEM;
 
-$: searchedOptions = getSearchResults(options, value, sort);
+const optionElements: Record<string, HTMLElement> = {};
+let inputElement: HTMLInputElement | undefined;
+let autoSelectIndex = -1;
+let menuState: MenuState | undefined;
 
-const {
-  isOpen,
-  isKeyboardControlling,
-  navigationIndex,
-  close,
-  resetNavigationIndex,
-  handleNavigation,
-  handleFocus,
-  handleOptionFocus,
-} = selectControls();
+$: searchResults = getSearchResults(options, value, sort);
+$: valueInSearch = searchResults.some(({ option }) => option === value);
+$: otherOption =
+  !exclusive && value !== '' && !valueInSearch
+    ? { option: value, priority: -1, highlight: undefined }
+    : undefined;
 
-const handleInput = (event: Event) => {
-  event.preventDefault();
-  resetNavigationIndex();
-  menu.scrollTop = 0;
-  dispatch('search', value ?? '');
-};
+$: allOptions = otherOption ? [...searchResults, otherOption] : searchResults;
+$: menuState = !menuState || allOptions.length === 0 ? CLOSED : menuState;
 
-const handleButtonClick = () => dispatch('buttonclick');
-
-const handleKeyDown = (event: KeyboardEvent, isButton = false) => {
-  if (
-    handleNavigation(
-      event,
-      menu,
-      button === undefined ? searchedOptions.length : searchedOptions.length + 1
-    )
-  ) {
-    return;
-  }
-
-  if (isButton) {
-    return;
-  }
-
-  if (event.code.toLowerCase() === 'enter') {
-    handleEnter();
-  }
-};
-
-const handleEnter = () => {
-  if ($navigationIndex > -1) {
-    value = searchedOptions[$navigationIndex]!.option;
-  } else {
-    const result = searchedOptions.find(
-      ({ option }) => option.toLowerCase() === value
-    );
-
-    if (result) {
-      value = result.option;
-    }
-  }
-
-  if ($isOpen) {
-    close();
-  }
-
-  dispatch('input', value);
-};
-
-const handleSelect = (option: string) => {
-  close();
-
-  if (value === option) {
-    return;
-  }
-
-  value = option;
-  dispatch('input', value);
-};
-
-$: {
-  if (!$isOpen && value && !options.includes(value)) {
-    value = undefined;
-    dispatch('input', value);
-  }
+$: if (menuState === undefined || menuState === FOCUS_SEARCH) {
+  autoSelectIndex = allOptions.findIndex(({ priority }) => priority !== -1);
+} else if (menuState === CLOSED) {
+  autoSelectIndex = -1;
 }
+
+$: autoSelectOption = allOptions[autoSelectIndex] ?? otherOption;
+$: isExpanded = menuState === FOCUS_SEARCH || menuState === FOCUS_ITEM;
+$: activeOption = isExpanded ? autoSelectOption : undefined;
+$: activeID = activeOption ? SELECTED_ID : undefined;
+
+$: if (activeOption) {
+  optionElements[activeOption.option]?.scrollIntoView({ block: 'nearest' });
+}
+
+const setMenuState = (nextMenuState: MenuState) => {
+  menuState = disabled ? CLOSED : nextMenuState;
+};
+
+const handleInput = () => {
+  setMenuState(FOCUS_SEARCH);
+};
+
+const handleFocus = (event: FocusEvent) => {
+  setMenuState(FOCUS_SEARCH);
+  onFocus?.(event);
+};
+
+const handleBlur = (event: FocusEvent) => {
+  handleSelect(autoSelectOption?.option);
+  onBlur?.(event);
+};
+
+const handleSelect = (nextValue: string | undefined) => {
+  const fallback = exclusive && !valueInSearch ? '' : value;
+  setMenuState(CLOSED);
+  value = nextValue ?? fallback;
+  onChange?.(value);
+};
+
+const handleButtonClick = () => {
+  setMenuState(isExpanded ? CLOSED : FOCUS_SEARCH);
+  inputElement?.focus();
+};
+
+const handleKeydown = createHandleKey({
+  Enter: () => {
+    handleSelect(autoSelectOption?.option);
+  },
+  Escape: () => {
+    if (menuState === CLOSED) {
+      value = '';
+    }
+    setMenuState(CLOSED);
+  },
+  ArrowDown: (event) => {
+    if (event.altKey) {
+      setMenuState(menuState === CLOSED ? FOCUS_SEARCH : FOCUS_ITEM);
+    } else {
+      setMenuState(FOCUS_ITEM);
+      autoSelectIndex =
+        autoSelectIndex < allOptions.length - 1 ? autoSelectIndex + 1 : 0;
+    }
+  },
+  ArrowUp: () => {
+    setMenuState(FOCUS_ITEM);
+    autoSelectIndex =
+      autoSelectIndex > 0 ? autoSelectIndex - 1 : allOptions.length - 1;
+  },
+  ArrowRight: {
+    handler: () => setMenuState(FOCUS_SEARCH),
+    preventDefault: false,
+  },
+  ArrowLeft: {
+    handler: () => setMenuState(FOCUS_SEARCH),
+    preventDefault: false,
+  },
+  Home: () => {
+    setMenuState(FOCUS_SEARCH);
+    inputElement?.setSelectionRange(0, 0);
+  },
+  End: () => {
+    setMenuState(FOCUS_SEARCH);
+    inputElement?.setSelectionRange(value.length, value.length);
+  },
+});
 </script>
 
-<div
-  class={cx('relative flex h-fit w-full', extraClasses)}
-  use:clickOutside={close}
+<SelectInput
+  {state}
+  {disabled}
+  {placeholder}
+  menuId={LIST_ID}
+  isOpen={isExpanded}
+  isFocused={menuState === FOCUS_ITEM ? false : undefined}
+  cx={[{ 'caret-transparent': menuState === FOCUS_ITEM }, inputCx]}
+  aria-autocomplete="list"
+  aria-activedescendant={activeID}
+  aria-errormessage={errorID}
+  on:focus={handleFocus}
+  on:blur={handleBlur}
+  on:keydown={handleKeydown}
+  on:input={handleInput}
+  on:click={handleButtonClick}
+  bind:inputElement
+  bind:value
+/>
+<Floating
+  matchWidth
+  offset={4}
+  referenceElement={inputElement}
 >
-  <SelectInput
-    bind:value
-    isOpen={$isOpen}
-    {menuId}
-    {disabled}
-    {state}
-    {...$$restProps}
-    on:input={handleInput}
-    on:keydown={handleKeyDown}
-    on:focus={() => handleFocus(disabled)}
-    on:mousemove={() => ($isKeyboardControlling = false)}
-    on:click={() => ($isOpen ? close() : handleFocus(disabled))}
-  />
+  <ul
+    id={LIST_ID}
+    role="listbox"
+    class:hidden={!isExpanded}
+    class="max-h-36 flex-col overflow-y-auto border border-gray-9 bg-white py-1 drop-shadow-md"
+  >
+    {#each allOptions as { option, highlight } (option)}
+      {@const isSelected = activeOption?.option === option}
+      {@const isOther = otherOption?.option === option}
 
-  {#if !disabled}
-    <SelectMenu
-      open={$isOpen}
-      id={menuId}
-      bind:element={menu}
-      on:mouseleave={resetNavigationIndex}
-    >
-      {#if heading}
+      {#if isOther}
         <li
-          role="presentation"
-          class="flex flex-wrap py-1 pl-2 text-xs text-default"
-        >
-          {heading}
-        </li>
+          role="none"
+          class="mb-0.5 mt-[3px] border-b border-light"
+        />
       {/if}
-
-      {#if searchedOptions.length > 0}
-        {#each searchedOptions as { highlight, option }, index (option)}
-          <li role="presentation">
-            <button
-              role="menuitem"
-              tabindex="-1"
-              class={cx(
-                'flex h-7.5 w-full items-center text-ellipsis whitespace-nowrap px-2 text-xs outline-none',
-                {
-                  'bg-light': $navigationIndex === index,
-                }
-              )}
-              on:mouseenter={() => handleOptionFocus(index)}
-              on:keydown={handleKeyDown}
-              on:click|preventDefault={() => handleSelect(option)}
-            >
-              {#if highlight !== undefined}
-                <span class="flex w-full text-ellipsis whitespace-nowrap">
-                  <span class="whitespace-pre">{highlight[0]}</span>
-                  <span class="whitespace-pre bg-yellow-100"
-                    >{highlight[1]}</span
-                  >
-                  <span class="whitespace-pre">{highlight[2]}</span>
-                </span>
-              {:else}
-                {option}
-              {/if}
-            </button>
-          </li>
-        {/each}
-      {:else}
-        <li class="flex justify-center px-2 py-1 text-xs">
-          No matching results
-        </li>
-      {/if}
-
-      {#if button !== undefined}
-        <SelectMenuButton
-          icon={button.icon}
-          cx={[
-            'border-t border-light',
-            {
-              'bg-light': $navigationIndex === searchedOptions.length,
-            },
-          ]}
-          on:click={handleButtonClick}
-          on:mouseenter={() => handleOptionFocus(searchedOptions.length)}
-          on:keydown={(event) => handleKeyDown(event, true)}
-        >
-          {button.text}
-        </SelectMenuButton>
-      {/if}
-    </SelectMenu>
-  {/if}
-</div>
+      <!--
+        Focus stays on combobox per WAI; key handlers on options not needed.
+        svelte-ignore a11y-click-events-have-key-events
+      -->
+      <li
+        role="option"
+        id={isSelected ? activeID : undefined}
+        aria-selected={isSelected}
+        aria-label={isOther ? `other: ${option}` : option}
+        class={cx(
+          'flex h-7.5 w-full cursor-pointer items-center justify-start text-ellipsis whitespace-nowrap px-2.5 text-xs',
+          isSelected ? 'bg-light' : 'hover:bg-light'
+        )}
+        on:click={() => handleSelect(option)}
+        bind:this={optionElements[option]}
+      >
+        {#if isOther}
+          <Icon
+            cx="mr-1 text-gray-6"
+            name="plus"
+          />
+        {/if}
+        {#if highlight !== undefined}
+          <span class="whitespace-pre">{highlight[0]}</span>
+          <span class="whitespace-pre bg-yellow-100">{highlight[1]}</span>
+          <span class="whitespace-pre">{highlight[2]}</span>
+        {:else}
+          {option}
+        {/if}
+      </li>
+    {/each}
+    <slot />
+  </ul>
+</Floating>

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -47,6 +47,9 @@ export let state: InputState = InputStates.NONE;
 /** Option sorting behavior. */
 export let sort: SortOption = SortOptions.DEFAULT;
 
+/** Prefix to display with the arbitrary text option, if non-exclusive. */
+export let otherOptionPrefix = '';
+
 /** Error message ID, if any. */
 export let errorID = '';
 
@@ -231,7 +234,9 @@ const handleKeydown = createHandleKey({
         role="option"
         id={isSelected ? activeID : undefined}
         aria-selected={isSelected}
-        aria-label={isOther ? `other: ${option}` : option}
+        aria-label={isOther
+          ? [otherOptionPrefix, option].filter(Boolean).join(' ')
+          : option}
         class={cx(
           'flex h-7.5 w-full cursor-pointer items-center justify-start text-ellipsis whitespace-nowrap px-2.5 text-xs',
           isSelected ? 'bg-light' : 'hover:bg-light'
@@ -251,6 +256,8 @@ const handleKeydown = createHandleKey({
           <span class="whitespace-pre">{highlight[0]}</span>
           <span class="whitespace-pre bg-yellow-100">{highlight[1]}</span>
           <span class="whitespace-pre">{highlight[2]}</span>
+        {:else if isOther && otherOptionPrefix}
+          {otherOptionPrefix} {option}
         {:else}
           {option}
         {/if}

--- a/packages/core/src/lib/select/select-input.svelte
+++ b/packages/core/src/lib/select/select-input.svelte
@@ -37,7 +37,7 @@ $: warnClasses =
   isWarn &&
   !disabled &&
   cx(
-    'border-warning-bright group-hover/select-input:outline-[1.5px] group-hover/select-input:-outline-offset-1 group-hover/select-input:outline-warning-bright',
+    'border-warning-bright bg-white group-hover/select-input:outline-[1.5px] group-hover/select-input:-outline-offset-1 group-hover/select-input:outline-warning-bright',
     {
       'focus:outline-[1.5px] focus:-outline-offset-1 focus:outline-warning-bright':
         isFocused !== false,
@@ -48,7 +48,7 @@ $: errorClasses =
   isError &&
   !disabled &&
   cx(
-    'border-danger-dark group-hover/select-input:outline-[1.5px] group-hover/select-input:-outline-offset-1 group-hover/select-input:outline-danger-dark',
+    'border-danger-dark bg-white group-hover/select-input:outline-[1.5px] group-hover/select-input:-outline-offset-1 group-hover/select-input:outline-danger-dark',
     {
       'focus:outline-[1.5px] focus:-outline-offset-1 focus:outline-danger-dark':
         isFocused !== false,

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1280,6 +1280,7 @@ const onHoverDelayMsInput = (event: Event) => {
     <SearchableSelect
       options={['First Option', 'Option 2', 'C.) Option']}
       placeholder="With arbitrary input"
+      otherOptionPrefix="Arbitrary:"
     />
     <SearchableSelect
       exclusive

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1245,19 +1245,44 @@ const onHoverDelayMsInput = (event: Event) => {
 
   <div class="flex gap-4">
     <SearchableSelect
+      exclusive
       options={['First Option', 'Option 2', 'C.) Option']}
       placeholder="Select an option"
-      on:input={(event) => {
+      onChange={(value) => {
         // eslint-disable-next-line no-console
-        console.log('SearchableSelect input', event);
+        console.log('Selected', value);
       }}
     />
     <SearchableSelect
+      exclusive
       options={['First Option', 'Disabled select', 'C.) Option']}
       value="Disabled select"
       disabled
     />
+  </div>
+
+  <div class="flex gap-4">
     <SearchableSelect
+      exclusive
+      options={['First Option', 'Option 2', 'C.) Option']}
+      placeholder="Warn state"
+      state="warn"
+    />
+    <SearchableSelect
+      exclusive
+      options={['First Option', 'Option 2', 'C.) Option']}
+      placeholder="Error state"
+      state="error"
+    />
+  </div>
+
+  <div class="flex gap-4">
+    <SearchableSelect
+      options={['First Option', 'Option 2', 'C.) Option']}
+      placeholder="With arbitrary input"
+    />
+    <SearchableSelect
+      exclusive
       options={[
         'First Option',
         'Option 2',
@@ -1270,32 +1295,6 @@ const onHoverDelayMsInput = (event: Event) => {
       ]}
       placeholder="Reducing Select"
       sort="reduce"
-    />
-  </div>
-
-  <div class="flex gap-4">
-    <SearchableSelect
-      options={['First Option', 'Option 2', 'C.) Option']}
-      placeholder="Warn state"
-      state="warn"
-    />
-    <SearchableSelect
-      options={['First Option', 'Option 2', 'C.) Option']}
-      placeholder="Error state"
-      state="error"
-    />
-  </div>
-
-  <div class="flex gap-4">
-    <SearchableSelect
-      options={['First Option', 'Option 2', 'C.) Option']}
-      placeholder="With a button"
-      button={{ text: 'Other', icon: 'information-outline' }}
-    />
-    <SearchableSelect
-      options={['First Option', 'Option 2', 'C.) Option']}
-      placeholder="With a heading"
-      heading="Some heading text"
     />
   </div>
 

--- a/packages/storybook/src/stories/select.mdx
+++ b/packages/storybook/src/stories/select.mdx
@@ -28,6 +28,10 @@ import { SearchableSelect } from '@viamrobotics/prime-core';
   <Story of={SelectStories.Searchable} />
 </Canvas>
 
+<Canvas>
+  <Story of={SelectStories.SearchableWithArbitraryText} />
+</Canvas>
+
 # Multiselect
 
 A user input for selecting multiple options from a list that can be filtered via text search.

--- a/packages/storybook/src/stories/select.stories.svelte
+++ b/packages/storybook/src/stories/select.stories.svelte
@@ -48,6 +48,7 @@ import {
     <SearchableSelect
       slot="input"
       placeholder="Search lyrics or invent your own"
+      otherOptionPrefix="Other:"
       options={['Hello', 'From', 'The other side']}
       sort={SortOptions.REDUCE}
     />

--- a/packages/storybook/src/stories/select.stories.svelte
+++ b/packages/storybook/src/stories/select.stories.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
 import { Meta, Story } from '@storybook/addon-svelte-csf';
 import {
+  Label,
   Multiselect,
   SearchableSelect,
   Select,
+  SortOptions,
 } from '@viamrobotics/prime-core';
 </script>
 
@@ -23,8 +25,11 @@ import {
 </Story>
 
 <Story name="Searchable">
-  <div class="h-[200px]">
+  <Label cx="h-[200px]">
+    Searchable select with limited options
     <SearchableSelect
+      slot="input"
+      placeholder="Search options"
       options={[
         'First Option',
         'Option 2',
@@ -32,8 +37,21 @@ import {
         'Something Else',
         'With A Whole Lot Of Parts',
       ]}
+      exclusive
     />
-  </div>
+  </Label>
+</Story>
+
+<Story name="Searchable with arbitrary text">
+  <Label cx="h-[200px]">
+    Select with arbitrary text
+    <SearchableSelect
+      slot="input"
+      placeholder="Search lyrics or invent your own"
+      options={['Hello', 'From', 'The other side']}
+      sort={SortOptions.REDUCE}
+    />
+  </Label>
 </Story>
 
 <Story name="Multi">


### PR DESCRIPTION
## Overview

This rebuilds the `<SearchableSelect>` from the ground up with the following goals:

- Fix a11y of the element so it follows [Editable Combobox With List Autocomplete Example](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/) from the ARIA APG
    - Elements should be a  `combobox` and `listbox`; currently it is a `combobox` and a `menu`, which turns out, is not correct! (This is also a problem with the resource picker over in app)
    - DOM focus should remain in the `<input role="combobox">` while options are highlighted, using `aria-activedescendant` to manage visual/a11y focus
    - Keyboard handlers should follow WAI recommendations
- Update props of the component to match needs + actual usage
    - Nothing uses the `heading` props, and it wasn't in Figma, so I removed it
    - Add `onFocus` and `onBlur` handlers for validation triggers
    - Replaced events with function props
- Allow arbitrary input values
    - New `exclusive` prop sets the select to allow arbitrary input (default) or exclude it
    - Going off existing usage in the app and the designs, I removed the `button` prop since it didn't quite capture the intent
    - Instead, if `exclusive` is `false` and the search doesn't match an option, a new option at the bottom with a `plus` icon and the current `value` will appear
- Ensure unit tests of `<SearchableSelect>` actually test the a11y
- Fix errant form submissions due to lack of `type="button"` on vanilla `<button>` elements 
- Fix input lockups where the menu can close and you can no longer type into it
- Fix various styling issues (e.g. incorrect menu and option padding)

## Change log

- Rewrite `<SearchableSelect>` and its tests
- Pull in `$lib/keyboard.ts` from the app, where it's been really helpful to declare keyboard interactions

### Notable features

- Allow arbitrary input by default (see above)
- Explicit `errorID` prop for `aria-errormessage`

### Notable removals

- `heading` prop removed (see above)
- `button` prop removed (see above)
- Sync keyboard state with mouse hover state removed
    - The APG example didn't do it as far as I could tell
    - I don't think the extra implementation required is worth the noise, and hover handlers seem to be a source of bugs in the existing `<SearchableSelect>`

## Review requests

Please smoke test the new `<SearchableSelect>` along with the old `<MultiSelect>`, which still uses a lot of infrastructure built for `<SearchableSelect>`. Be on the lookout for styling regressions. If you find any behavior bugs with `<MultiSelect>`, try to figure out if they're regressions of if it's buggy on `main`.

- [ ] Storybook
- [ ] Playground

In the mean time, I'll be prepping an app PR to incorporate these breaking changes