### PR TITLE
APP-3126: remove scrollIntoView mock

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,6 +28,7 @@
     "combobox",
     "listbox",
     "radiobox",
+    "unstub",
     "viamrobotics"
   ]
 }

--- a/packages/blocks/vite.config.ts
+++ b/packages/blocks/vite.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
     setupFiles: ['src/vitest.setup.ts'],
     environment: 'jsdom',
     mockReset: true,
+    unstubGlobals: true,
   },
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.77",
+  "version": "0.0.78",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -102,9 +102,12 @@ $: autoSelectOption = allOptions[autoSelectIndex] ?? otherOption;
 $: isExpanded = menuState === FOCUS_SEARCH || menuState === FOCUS_ITEM;
 $: activeOption = isExpanded ? autoSelectOption : undefined;
 $: activeID = activeOption ? SELECTED_ID : undefined;
+$: activeElement = activeOption
+  ? optionElements[activeOption.option]
+  : undefined;
 
-$: if (activeOption) {
-  optionElements[activeOption.option]?.scrollIntoView({ block: 'nearest' });
+$: if (typeof activeElement?.scrollIntoView === 'function') {
+  activeElement.scrollIntoView({ block: 'nearest' });
 }
 
 const setMenuState = (nextMenuState: MenuState) => {

--- a/packages/core/src/vitest.setup.ts
+++ b/packages/core/src/vitest.setup.ts
@@ -1,43 +1,44 @@
-import { beforeAll, afterEach, vi } from 'vitest';
+import { afterEach } from 'vitest';
 import { cleanup } from '@testing-library/svelte';
 import '@testing-library/jest-dom/vitest';
 
-beforeAll(() => {
-  /**
-   * `PointerEvent` does not exist in `jsdom` so this polyfill is based off this
-   * comment on the PR to add it:
-   *
-   * https://github.com/jsdom/jsdom/pull/2666#issuecomment-691216178
-   */
-  vi.stubGlobal(
-    'PointerEvent',
-    class PointerEvent extends MouseEvent {
-      public height: number | undefined;
-      public isPrimary: boolean | undefined;
-      public pointerId: number | undefined;
-      public pointerType: string | undefined;
-      public pressure: number | undefined;
-      public tangentialPressure: number | undefined;
-      public tiltX: number | undefined;
-      public tiltY: number | undefined;
-      public twist: number | undefined;
-      public width: number | undefined;
+/**
+ * `PointerEvent` does not exist in `jsdom` so this polyfill is based off this
+ * comment on the PR to add it:
+ *
+ * https://github.com/jsdom/jsdom/pull/2666#issuecomment-691216178
+ */
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+if (!global.PointerEvent) {
+  class PointerEvent extends MouseEvent {
+    public height: number | undefined;
+    public isPrimary: boolean | undefined;
+    public pointerId: number | undefined;
+    public pointerType: string | undefined;
+    public pressure: number | undefined;
+    public tangentialPressure: number | undefined;
+    public tiltX: number | undefined;
+    public tiltY: number | undefined;
+    public twist: number | undefined;
+    public width: number | undefined;
 
-      constructor(type: string, params: PointerEventInit = {}) {
-        super(type, params);
-        this.pointerId = params.pointerId;
-        this.width = params.width;
-        this.height = params.height;
-        this.pressure = params.pressure;
-        this.tangentialPressure = params.tangentialPressure;
-        this.tiltX = params.tiltX;
-        this.tiltY = params.tiltY;
-        this.pointerType = params.pointerType;
-        this.isPrimary = params.isPrimary;
-      }
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId;
+      this.width = params.width;
+      this.height = params.height;
+      this.pressure = params.pressure;
+      this.tangentialPressure = params.tangentialPressure;
+      this.tiltX = params.tiltX;
+      this.tiltY = params.tiltY;
+      this.pointerType = params.pointerType;
+      this.isPrimary = params.isPrimary;
     }
-  );
-});
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
+  global.PointerEvent = PointerEvent as any;
+}
 
 afterEach(() => {
   cleanup();

--- a/packages/core/src/vitest.setup.ts
+++ b/packages/core/src/vitest.setup.ts
@@ -1,52 +1,43 @@
-import { afterEach, vi } from 'vitest';
+import { beforeAll, afterEach, vi } from 'vitest';
 import { cleanup } from '@testing-library/svelte';
 import '@testing-library/jest-dom/vitest';
 
-/**
- * `Element.scrollIntoView` is not implemented/stubbed in `jsdom` so we stub it
- * out here:
- *
- * https://github.com/jsdom/jsdom/issues/1695
- */
-Element.prototype.scrollIntoView = vi.fn();
+beforeAll(() => {
+  /**
+   * `PointerEvent` does not exist in `jsdom` so this polyfill is based off this
+   * comment on the PR to add it:
+   *
+   * https://github.com/jsdom/jsdom/pull/2666#issuecomment-691216178
+   */
+  vi.stubGlobal(
+    'PointerEvent',
+    class PointerEvent extends MouseEvent {
+      public height: number | undefined;
+      public isPrimary: boolean | undefined;
+      public pointerId: number | undefined;
+      public pointerType: string | undefined;
+      public pressure: number | undefined;
+      public tangentialPressure: number | undefined;
+      public tiltX: number | undefined;
+      public tiltY: number | undefined;
+      public twist: number | undefined;
+      public width: number | undefined;
 
-/**
- * `PointerEvent` does not exist in `jsdom` so this polyfill is based off this
- * comment on the PR to add it:
- *
- * https://github.com/jsdom/jsdom/pull/2666#issuecomment-691216178
- */
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-if (!global.PointerEvent) {
-  class PointerEvent extends MouseEvent {
-    public height: number | undefined;
-    public isPrimary: boolean | undefined;
-    public pointerId: number | undefined;
-    public pointerType: string | undefined;
-    public pressure: number | undefined;
-    public tangentialPressure: number | undefined;
-    public tiltX: number | undefined;
-    public tiltY: number | undefined;
-    public twist: number | undefined;
-    public width: number | undefined;
-
-    constructor(type: string, params: PointerEventInit = {}) {
-      super(type, params);
-      this.pointerId = params.pointerId;
-      this.width = params.width;
-      this.height = params.height;
-      this.pressure = params.pressure;
-      this.tangentialPressure = params.tangentialPressure;
-      this.tiltX = params.tiltX;
-      this.tiltY = params.tiltY;
-      this.pointerType = params.pointerType;
-      this.isPrimary = params.isPrimary;
+      constructor(type: string, params: PointerEventInit = {}) {
+        super(type, params);
+        this.pointerId = params.pointerId;
+        this.width = params.width;
+        this.height = params.height;
+        this.pressure = params.pressure;
+        this.tangentialPressure = params.tangentialPressure;
+        this.tiltX = params.tiltX;
+        this.tiltY = params.tiltY;
+        this.pointerType = params.pointerType;
+        this.isPrimary = params.isPrimary;
+      }
     }
-  }
-
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-explicit-any
-  global.PointerEvent = PointerEvent as any;
-}
+  );
+});
 
 afterEach(() => {
   cleanup();

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     setupFiles: ['src/vitest.setup.ts'],
     environment: 'jsdom',
     mockReset: true,
+    unstubGlobals: true,
     // For testing svelte internals like onMount, see: https://github.com/vitest-dev/vitest/issues/2834
     alias: [{ find: /^svelte$/u, replacement: 'svelte/internal' }],
   },


### PR DESCRIPTION
## Overview

Missed a potential SSR bug in `<SearchableSelect>` due to a global mock of `scrollIntoView` in the `prime-core` tests. This PR removes the mock and fixes the bug