### PR TITLE
RSDK-6218 - make postprocessed slam points the viam slam brand color "cyberpunk"

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-blocks",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blocks/src/lib/slam-map-2d/color-map.ts
+++ b/packages/blocks/src/lib/slam-map-2d/color-map.ts
@@ -45,13 +45,16 @@ const colorBuckets = (probability: number): THREE.Vector3 => {
 export const mapColorAttributeGrayscale = (colors: THREE.BufferAttribute) => {
   for (let i = 0; i < colors.count; i += 1) {
     /*
-     * Probability is currently assumed to be held in the rgb field of the PCD map, on a scale of 0 to 100.
-     * ticket to look into this further https://viam.atlassian.net/browse/RSDK-2605
+     * Probability is currently assumed to be held in the b part of the rgb field of the PCD map, on a scale of 0 to 100.
+     * ticket to look into this further https://viam.atlassian.net/browse/RSDK-2605. 
+     * 
+     * User generated points that have been added to the pcd are marked as such by putting 100% probability
+     * in the r part of the rgb field. If that has been set, we will draw the point in blue instead of mapping it to its
+     * corresponding shade of gray to signal it is a user generated point.
      */
 
-    // if the point has been postprocessed
     if (colors.getX(i) === 1) {
-      colors.setXYZ(i, 0.8, 0, 0);
+      colors.setXYZ(i, 0, 0, 1);
       continue;
     }
 

--- a/packages/blocks/src/lib/slam-map-2d/color-map.ts
+++ b/packages/blocks/src/lib/slam-map-2d/color-map.ts
@@ -51,10 +51,10 @@ export const mapColorAttributeGrayscale = (colors: THREE.BufferAttribute) => {
 
     // if the point has been postprocessed
     if (colors.getX(i) === 1) {
-      colors.setXYZ(i, .8, 0, 0);
-      continue
+      colors.setXYZ(i, 0.8, 0, 0);
+      continue;
     }
-    
+
     const colorMapPoint = colorBuckets(colors.getZ(i) * 10);
     colors.setXYZ(i, colorMapPoint.x, colorMapPoint.y, colorMapPoint.z);
   }

--- a/packages/blocks/src/lib/slam-map-2d/color-map.ts
+++ b/packages/blocks/src/lib/slam-map-2d/color-map.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { theme } from '@viamrobotics/prime-core/theme';
 
 /*
  * this color map is greyscale. The color map is being used map probability values of a PCD
@@ -18,6 +19,9 @@ const colorMapGrey = [
   [0, 0, 0],
 ].map(([red, green, blue]) =>
   new THREE.Vector3(red, green, blue).multiplyScalar(1 / 255)
+);
+const USER_GENERATED_POINT_COLOR = new THREE.Color(
+  theme.extend.colors.cyberpunk
 );
 
 /*
@@ -54,7 +58,12 @@ export const mapColorAttributeGrayscale = (colors: THREE.BufferAttribute) => {
      */
 
     if (colors.getX(i) === 1) {
-      colors.setXYZ(i, 0, 0, 1);
+      colors.setXYZ(
+        i,
+        USER_GENERATED_POINT_COLOR.r,
+        USER_GENERATED_POINT_COLOR.g,
+        USER_GENERATED_POINT_COLOR.b
+      );
       continue;
     }
 

--- a/packages/blocks/src/lib/slam-map-2d/color-map.ts
+++ b/packages/blocks/src/lib/slam-map-2d/color-map.ts
@@ -48,6 +48,13 @@ export const mapColorAttributeGrayscale = (colors: THREE.BufferAttribute) => {
      * Probability is currently assumed to be held in the rgb field of the PCD map, on a scale of 0 to 100.
      * ticket to look into this further https://viam.atlassian.net/browse/RSDK-2605
      */
+
+    // if the point has been postprocessed
+    if (colors.getX(i) === 1) {
+      colors.setXYZ(i, .8, 0, 0);
+      continue
+    }
+    
     const colorMapPoint = colorBuckets(colors.getZ(i) * 10);
     colors.setXYZ(i, colorMapPoint.x, colorMapPoint.y, colorMapPoint.z);
   }

--- a/packages/blocks/src/lib/slam-map-2d/color-map.ts
+++ b/packages/blocks/src/lib/slam-map-2d/color-map.ts
@@ -46,8 +46,8 @@ export const mapColorAttributeGrayscale = (colors: THREE.BufferAttribute) => {
   for (let i = 0; i < colors.count; i += 1) {
     /*
      * Probability is currently assumed to be held in the b part of the rgb field of the PCD map, on a scale of 0 to 100.
-     * ticket to look into this further https://viam.atlassian.net/browse/RSDK-2605. 
-     * 
+     * ticket to look into this further https://viam.atlassian.net/browse/RSDK-2605.
+     *
      * User generated points that have been added to the pcd are marked as such by putting 100% probability
      * in the r part of the rgb field. If that has been set, we will draw the point in blue instead of mapping it to its
      * corresponding shade of gray to signal it is a user generated point.


### PR DESCRIPTION
This PR makes postprocessed points from the SLAM map  the viam slam brand color "cyberpunk". Regular points only have confidence in the B value, but for postprocessed points we send 100 percent confidence through the red value. Because of this, we can check X and set the color accordingly. 
![screenshot_2024-01-10_at_12 24 02_pm_720](https://github.com/viamrobotics/prime/assets/121991867/4cb36f59-88db-4c75-8679-43337fafea29)
