### PR TITLE
Do not add a color class to icon

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.80",
+  "version": "0.0.81",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/icon/icon.svelte
+++ b/packages/core/src/lib/icon/icon.svelte
@@ -41,8 +41,6 @@ export let size: Size = 'base';
 /** Additional CSS classes to pass to the svg. */
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
-
-const hasNameProperty = Object.hasOwn(paths, name);
 </script>
 
 <!--
@@ -50,14 +48,7 @@ const hasNameProperty = Object.hasOwn(paths, name);
   https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-label
 -->
 <svg
-  class={cx(
-    'text-gray-6',
-    sizes[size],
-    {
-      hidden: !hasNameProperty,
-    },
-    extraClasses
-  )}
+  class={cx(sizes[size], extraClasses)}
   viewBox="0 0 24 24"
   aria-hidden="true"
   focusable="false"


### PR DESCRIPTION
## Overview

#456 added the `text-gray-6` class to the `<Icon>` component. This, in turn, made it impossible to override the color of an icon with any class that comes later in the Tailwind stylesheet, because `text-gray-6` will always be present, so color will be applied according to CSS specificity.

The PR reverts that addition, which will cause all icons to default to the current text color, fixing several regressions in the app. If we want to default icons to a specific color, we will need to come up with a different approach that conditionally adds a color classname

## Change log

- Remove `text-gray-6` from icon