### PR TITLE
RSDK-6093 - Fix Lat,Lng order is flipped in nav service rc card

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-blocks",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blocks/src/lib/navigation-map/components/nav/waypoints.svelte
+++ b/packages/blocks/src/lib/navigation-map/components/nav/waypoints.svelte
@@ -49,7 +49,7 @@ useMapLibreEvent('click', (event) => {
   >
     <small>Waypoint {index}</small>
     <small class="text-subtle-2 opacity-60 group-hover:opacity-100">
-      ({waypoint.lng.toFixed(4)}, {waypoint.lat.toFixed(4)})
+      ({waypoint.lat.toFixed(4)}, {waypoint.lng.toFixed(4)})
     </small>
     <div class="flex items-center gap-1.5">
       <IconButton


### PR DESCRIPTION
[Ticket](https://viam.atlassian.net/browse/RSDK-6093)

Swaps the order of (lng, lat) in the Waypoints tab on the nav RC card.

Before:
![Screenshot 2024-01-11 at 2 42 24 PM](https://github.com/viamrobotics/prime/assets/5927876/8be8ae6f-bece-47c1-af69-45315508f212)

After:
![Screenshot 2024-01-11 at 2 41 03 PM](https://github.com/viamrobotics/prime/assets/5927876/b032e6b1-58fa-4250-bef8-7f74dea8b2ce)

