### PR TITLE
Fix: storybook for labels

### DIFF
--- a/packages/storybook/src/stories/label.stories.svelte
+++ b/packages/storybook/src/stories/label.stories.svelte
@@ -5,7 +5,7 @@ import { Label } from '@viamrobotics/prime-core';
 
 <Meta title="Elements/Label" />
 
-<Story name="Basic">
+<Story name="Input">
   <Label>
     Name:
     <input


### PR DESCRIPTION
The story references a story called "input", not "basic"