### PR TITLE
APP-3302: add `multiple` prop to `<SearchableSelect>`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     "activedescendant",
     "combobox",
     "listbox",
+    "multiselectable",
     "radiobox",
     "unstub",
     "viamrobotics"

--- a/packages/core/src/lib/icon/icons.ts
+++ b/packages/core/src/lib/icon/icons.ts
@@ -29,6 +29,8 @@ export const paths = {
   cancel: MDI.mdiCancel,
   'check-circle': MDI.mdiCheckCircle,
   check: MDI.mdiCheck,
+  'checkbox-blank-outline': MDI.mdiCheckboxBlankOutline,
+  'checkbox-marked': MDI.mdiCheckboxMarked,
   'chevron-double-up': MDI.mdiChevronDoubleUp,
   'chevron-down': MDI.mdiChevronDown,
   'chevron-left': MDI.mdiChevronLeft,

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -306,11 +306,10 @@ const handleKeydown = createHandleKey({
             name="plus"
           />
         {/if}
-        <p class="truncate">
+        <p class="truncate whitespace-pre">
           {#if highlight !== undefined}
-            <span class="whitespace-pre">{highlight[0]}</span>
-            <span class="whitespace-pre bg-yellow-100">{highlight[1]}</span>
-            <span class="whitespace-pre">{highlight[2]}</span>
+            {@const [prefix, match, suffix] = highlight}
+            {prefix}<span class="bg-yellow-100">{match}</span>{suffix}
           {:else if isOther && otherOptionPrefix}
             {otherOptionPrefix} {option}
           {:else}

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1301,6 +1301,7 @@ const onHoverDelayMsInput = (event: Event) => {
       ]}
       placeholder="Reducing Select"
       sort="reduce"
+      multiple
     />
   </div>
 

--- a/packages/storybook/src/stories/select.mdx
+++ b/packages/storybook/src/stories/select.mdx
@@ -41,5 +41,5 @@ import { Multiselect } from '@viamrobotics/prime-core';
 ```
 
 <Canvas>
-  <Story of={SelectStories.Multi} />
+  <Story of={SelectStories.SearchableWithMultiple} />
 </Canvas>

--- a/packages/storybook/src/stories/select.stories.svelte
+++ b/packages/storybook/src/stories/select.stories.svelte
@@ -2,7 +2,6 @@
 import { Meta, Story } from '@storybook/addon-svelte-csf';
 import {
   Label,
-  Multiselect,
   SearchableSelect,
   Select,
   SortOptions,
@@ -25,11 +24,10 @@ import {
 </Story>
 
 <Story name="Searchable">
-  <Label cx="h-[200px]">
+  <Label cx="h-[200px] max-w-[200px]">
     Searchable select
     <SearchableSelect
       slot="input"
-      cx="max-w-[200px]"
       placeholder="Search options"
       options={[
         'First option',
@@ -44,11 +42,10 @@ import {
 </Story>
 
 <Story name="Searchable with arbitrary text">
-  <Label cx="h-[200px]">
+  <Label cx="h-[200px] max-w-[200px]">
     Searchable select with create
     <SearchableSelect
       slot="input"
-      cx="max-w-[200px]"
       placeholder="Type to find or create..."
       otherOptionPrefix="Other:"
       options={['Hello', 'From', 'The other side']}
@@ -57,12 +54,11 @@ import {
   </Label>
 </Story>
 
-<Story name="Multi">
-  <Label cx="h-[200px]">
-    Select multiple objects
-    <Multiselect
+<Story name="Searchable with multiple">
+  <Label cx="h-[200px] max-w-[200px]">
+    Select multiple options
+    <SearchableSelect
       slot="input"
-      cx="max-w-[300px]"
       options={[
         'First option',
         'Second option',
@@ -70,6 +66,9 @@ import {
         'Something else',
         'With a whole lot of parts',
       ]}
+      sort={SortOptions.REDUCE}
+      exclusive
+      multiple
     />
   </Label>
 </Story>


### PR DESCRIPTION
## Overview

Back in #459, we made some minor fixes to the `<SearchableSelect>` element:

- Switch from `menu` to `listbox`, as recommended by WAI
- Keep DOM focus on search box, use `aria-activedescendant` for visual focus
- Minor visual fixes (e.g. padding)
- Switch to `floating-ui` for menu placement

This PR adds a `multiple` prop to allow the same `<SearchableSelect>` to be used to select multiple options.

## Change log

- Add `multiple` prop to `<SearchableSelect>`
- Add `bind`-able `values` prop for use when `multiple={true}`
- Add `onMultiChange` prop for use when `multiple={true}`

## Review requests

- Try out the storybook
- Try out the `core` playground

I did not touch `<Multiselect>` component in this PR. The main difference between the two is that `<Multiselect>` adds pills.

I think we can rework `<Multiselect>` to use `<SearchableSelect>` under the hood, but I'd rather tackle that later, because there's a few data pages that rely on the current component. There's also upcoming designs that display the pills in a slightly different way than before