### PR TITLE
Code-snippets padding fix

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.90",
+  "version": "0.0.91",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/code-snippet.svelte
+++ b/packages/core/src/lib/code-snippet.svelte
@@ -155,7 +155,7 @@ onMount(async () => {
     <figcaption><slot name="caption" /></figcaption>
   {/if}
 
-  <div class="flex items-baseline gap-x-4 bg-light p-2">
+  <div class="flex gap-x-4 p-4 bg-light">
     <!-- The formatting here is intentional to preserve the formatting of `code` -->
     <pre class="flex-1 overflow-x-auto language-{language}"><code
         bind:this={element}
@@ -165,7 +165,7 @@ onMount(async () => {
 
     {#if showCopyButton}
       <IconButton
-        cx="m-1 text-gray-6"
+        cx="text-gray-6"
         icon={COPY_STATES[copyState].icon}
         label={COPY_STATES[copyState].label}
         on:click={copyToClipboard}
@@ -186,8 +186,6 @@ figure pre[class*='language-'] > code[class*='language-'] {
 
 figure pre[class*='language-'] {
   padding: 0;
-  padding-left: 0.5rem;
-  padding-top: 0.5rem;
 }
 
 figure pre[class*='language-'] > code[class*='language-'] {


### PR DESCRIPTION
We had an ask from design to remove the padding from extra padding from the code snippets box

See here: https://github.com/viamrobotics/app/pull/3704

Removed the extra padding from the top and left of the code snippet component and added padding all around