### PR TITLE
APP-3851: Adjust navigation map spacing

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-blocks",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blocks/src/lib/navigation-map/components/nav/index.svelte
+++ b/packages/blocks/src/lib/navigation-map/components/nav/index.svelte
@@ -15,7 +15,7 @@ const handleUpdateObstacle = (event: CustomEvent<Obstacle[]>) => {
 };
 </script>
 
-<nav class="sm:h-full sm:w-[350px] py-4 pl-4">
+<nav class="py-4 pl-4 sm:h-full sm:w-[350px]">
   <ol class="mb-2 flex flex-wrap items-center">
     {#each $tabs as tabTitle}
       {@const selected = $tab === tabTitle}

--- a/packages/blocks/src/lib/navigation-map/components/nav/index.svelte
+++ b/packages/blocks/src/lib/navigation-map/components/nav/index.svelte
@@ -15,7 +15,7 @@ const handleUpdateObstacle = (event: CustomEvent<Obstacle[]>) => {
 };
 </script>
 
-<nav class="sm:h-full sm:w-[350px]">
+<nav class="sm:h-full sm:w-[350px] py-4 pl-4">
   <ol class="mb-2 flex flex-wrap items-center">
     {#each $tabs as tabTitle}
       {@const selected = $tab === tabTitle}

--- a/packages/blocks/src/routes/navigation-map.svelte
+++ b/packages/blocks/src/routes/navigation-map.svelte
@@ -186,7 +186,7 @@ $: map?.setCenter({ lat: 40.7, lng: -74.17 });
 
 <div class="px-12">
   <div
-    class="relative h-[800px] w-full border border-gray-200 p-4 sm:aspect-video sm:h-auto"
+    class="relative h-[800px] w-full border border-gray-200 sm:aspect-video sm:h-auto"
   >
     <NavigationMap
       bind:map


### PR DESCRIPTION
In R2D2:

<img width="857" alt="image" src="https://github.com/viamrobotics/prime/assets/5910938/a57a955f-8aa1-4701-8fc3-0ec1f71d4bef">

In legacy config:

<img width="987" alt="image" src="https://github.com/viamrobotics/prime/assets/5910938/92fb82de-9a20-40e8-84a0-b90c5f42f579">

In control tab:

<img width="1003" alt="image" src="https://github.com/viamrobotics/prime/assets/5910938/3981ae09-0015-4c62-9e8b-8cad17b94549">

Padding is definitely wonky in the old UI and control tab, but we're about to get rid of the old UI and the control tab already has a lot of jank.