### PR TITLE
APP-3908: ensure all buttons use `<button type="button">`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.98",
+  "version": "0.0.99",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/context-menu/context-menu-item.svelte
+++ b/packages/core/src/lib/context-menu/context-menu-item.svelte
@@ -29,6 +29,7 @@ export { extraClasses as cx };
 </script>
 
 <button
+  type="button"
   role="menuitem"
   class={cx(
     'flex w-full items-center gap-1.5 px-3 py-1.5 text-left hover:bg-light',

--- a/packages/core/src/lib/context-menu/floating-menu.svelte
+++ b/packages/core/src/lib/context-menu/floating-menu.svelte
@@ -37,6 +37,7 @@ const handleEscape = (event: KeyboardEvent) => {
 <svelte:window on:keydown={isOpen ? handleEscape : undefined} />
 
 <button
+  type="button"
   id={buttonID}
   class={cx(buttonCX)}
   aria-haspopup="menu"

--- a/packages/core/src/lib/input/slider-input.svelte
+++ b/packages/core/src/lib/input/slider-input.svelte
@@ -169,6 +169,7 @@ const handleChange = () => {
     on:change={handleChange}
   />
   <button
+    type="button"
     aria-hidden="true"
     disabled={isButtonDisabled}
     tabindex="-1"

--- a/packages/core/src/lib/pill.svelte
+++ b/packages/core/src/lib/pill.svelte
@@ -1,6 +1,6 @@
 <!--
 @component
-  
+
 For displaying a list of items.
 
 ```svelte
@@ -74,6 +74,7 @@ const handleRemove = () => {
   </span>
   {#if !readonly && removable}
     <button
+      type="button"
       aria-label="Remove {value}"
       on:click={handleRemove}
       class={cx('text-gray-6', {

--- a/packages/core/src/lib/tabs.svelte
+++ b/packages/core/src/lib/tabs.svelte
@@ -1,6 +1,6 @@
 <!--
 @component
-  
+
 A clickable element that allows the user to navigate to another page or area.
 
 ```svelte
@@ -42,6 +42,7 @@ const handleClick = (option: string) => {
 <div class={cx('flex w-full border-b bg-medium', extraClasses)}>
   {#each tabs as tab, index (tab)}
     <button
+      type="button"
       class={cx('px-4 py-1 text-sm first:ml-6', {
         'border-x-border-2 border-t-border-2 -mb-px border border-b-white bg-white font-semibold text-default':
           tab === selected,

--- a/packages/core/src/lib/toggle-buttons.svelte
+++ b/packages/core/src/lib/toggle-buttons.svelte
@@ -77,6 +77,7 @@ const handleClick = (value: string) => {
   <div class="flex w-full flex-nowrap">
     {#each options as option}
       <button
+        type="button"
         aria-pressed={isSelected(option)}
         aria-disabled={disabled ? true : undefined}
         class={cx(


### PR DESCRIPTION
## Overview

Inside a `<form>`, a `<button>` will implicitly become `type="submit"` if not specified. This is never what we want when using Prime components.

## Change log

- Specify `type="button"` for every vanilla `<button>` I could find in core