### PR TITLE
APP-4319: do not trigger an empty onChange from `SearchableSelect`

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.101",
+  "version": "0.0.102",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
@@ -156,7 +156,7 @@ describe('SearchableSelect', () => {
     expect(search).toHaveAttribute('aria-expanded', 'false');
   });
 
-  it('does not change the select when clicking and then blurring', async () => {
+  it('does not change the select when clicking and then blurring if disabled', async () => {
     const user = userEvent.setup();
     renderSubject({
       options: detailedOptions,
@@ -195,6 +195,7 @@ describe('SearchableSelect', () => {
 
     expect(search).toHaveFocus();
     expect(search).toHaveAttribute('aria-expanded', 'false');
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('collapses the listbox on blur', async () => {
@@ -208,6 +209,7 @@ describe('SearchableSelect', () => {
     expect(onBlur).toHaveBeenCalledOnce();
     expect(search).not.toHaveFocus();
     expect(search).toHaveAttribute('aria-expanded', 'false');
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it('has options', () => {

--- a/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
+++ b/packages/core/src/lib/select/__tests__/searchable-select.spec.ts
@@ -266,6 +266,22 @@ describe('SearchableSelect', () => {
     expect(search).not.toHaveAttribute('aria-activedescendant');
   });
 
+  it('subsequent blur after value reset does not trigger additional onChange', async () => {
+    const user = userEvent.setup();
+    const { component } = renderSubject({ value: 'hello from' });
+
+    const { search } = getResults();
+
+    // reset the value, click, and blur
+    await act(() => {
+      component.$set({ value: '' });
+    });
+    await user.click(search);
+    await user.keyboard('{Tab}');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('displays the correct icon and label on select', async () => {
     const user = userEvent.setup();
     renderSubject({ options: detailedOptions });

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -107,8 +107,6 @@ const optionElements: Record<string, HTMLElement> = {};
 let inputElement: HTMLInputElement | undefined;
 let autoSelectIndex = -1;
 let menuState: MenuState | undefined;
-// previousValue is used to ensure we don't double-call onChange
-let previousValue = value;
 
 // searchValue is the value stored inside the search input field
 // it is primarily updated reactively through a call to resetSearchValue when
@@ -188,9 +186,8 @@ const handleSingleSelect = (selectedOption: DetailedOption | undefined) => {
   // we always set the menu state to closed even if the value is equal to the previous value
   // but we don't call onChange
   setMenuState(CLOSED);
-  if (nextOption.value !== previousValue) {
+  if (nextOption.value !== value) {
     value = nextOption.value;
-    previousValue = nextOption.value;
     onChange?.(nextOption.value);
   }
 };

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -108,7 +108,7 @@ let inputElement: HTMLInputElement | undefined;
 let autoSelectIndex = -1;
 let menuState: MenuState | undefined;
 // previousValue is used to ensure we don't double-call onChange
-let previousValue: string | undefined = undefined;
+let previousValue = value;
 
 // searchValue is the value stored inside the search input field
 // it is primarily updated reactively through a call to resetSearchValue when


### PR DESCRIPTION
## Overview

The `<SearchableSelect>` can trigger an empty `onChange` if you blur it while empty. This PR fixes that bug. It looks like this was a previously existing bad behavior rather than a regression from recent work.

## Change log

With `value` separated from `searchValue`, the internal `previousValue` variable is no longer needed. Removing it fixes the bug

## Review requests

- Code changes make sense
- Test additions make sense