### PR TITLE
APP-4460: allow the height of a floating element to be constrained

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.102",
+  "version": "0.0.103",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/floating/floating-size.ts
+++ b/packages/core/src/lib/floating/floating-size.ts
@@ -1,9 +1,17 @@
 import type { FloatingSizeOptions } from './floating-style';
 
 export const matchWidth: FloatingSizeOptions = {
-  apply({ rects, elements }) {
+  apply: ({ rects, elements }) => {
     Object.assign(elements.floating.style, {
       width: `${rects.reference.width}px`,
     });
   },
 };
+
+export const limitHeight = (margin = 0): FloatingSizeOptions => ({
+  apply: ({ availableHeight, elements }) => {
+    Object.assign(elements.floating.style, {
+      maxHeight: `${availableHeight - margin}px`,
+    });
+  },
+});

--- a/packages/core/src/lib/floating/floating-style.ts
+++ b/packages/core/src/lib/floating/floating-style.ts
@@ -15,6 +15,7 @@ import {
   type FlipOptions,
   type ShiftOptions,
   type SizeOptions,
+  type Strategy,
 } from '@floating-ui/dom';
 
 import { derived, writable, type Readable } from 'svelte/store';
@@ -22,6 +23,7 @@ import { noop } from 'lodash-es';
 
 export type {
   Placement as FloatingPlacement,
+  Strategy as FloatingStrategy,
   ReferenceElement as FloatingReferenceElement,
   OffsetOptions as FloatingOffsetOptions,
   FlipOptions as FloatingFlipOptions,
@@ -56,6 +58,7 @@ export interface State {
   flip?: FlipOptions | undefined;
   shift?: ShiftOptions | undefined;
   size?: SizeOptions | undefined;
+  strategy?: Strategy | undefined;
   auto?: boolean;
 }
 
@@ -119,9 +122,11 @@ const calculateStyle = async (state: State): Promise<FloatingStyle> => {
 };
 
 const getConfig = (state: State): ComputePositionConfig => {
-  const { arrowElement, placement, offset, flip, shift, size } = state;
+  const { arrowElement, placement, offset, flip, shift, size, strategy } =
+    state;
 
   return {
+    strategy: strategy ?? 'absolute',
     placement: placement ?? 'top',
     middleware: [
       offset !== undefined && offsetMiddleware(offset),

--- a/packages/core/src/lib/floating/floating.svelte
+++ b/packages/core/src/lib/floating/floating.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import cx from 'classnames';
+import classnames from 'classnames';
 import { clickOutside } from '$lib/click-outside';
 import {
   floatingStyle,
@@ -8,6 +8,7 @@ import {
   type FloatingFlipOptions,
   type FloatingShiftOptions,
   type FloatingSizeOptions,
+  type FloatingStrategy,
 } from './floating-style';
 
 export let referenceElement: FloatingReferenceElement | undefined;
@@ -16,12 +17,11 @@ export let offset: number | undefined = undefined;
 export let flip: FloatingFlipOptions | undefined = undefined;
 export let shift: FloatingShiftOptions | undefined = undefined;
 export let size: FloatingSizeOptions | undefined = undefined;
+export let strategy: FloatingStrategy | undefined = undefined;
 export let auto = false;
 export let onClickOutside: ((target: Element) => unknown) | undefined =
   undefined;
-
-let className: cx.Argument = undefined;
-export { className as cx };
+export let cx: classnames.Argument = undefined;
 
 const style = floatingStyle();
 let floatingElement: HTMLElement | undefined;
@@ -34,13 +34,18 @@ $: style.register({
   flip,
   shift,
   size,
+  strategy,
   auto,
 });
 </script>
 
 <div
   bind:this={floatingElement}
-  class={cx('absolute left-0 top-0 z-max w-max', className)}
+  class={classnames(
+    'left-0 top-0 z-max w-max',
+    strategy === 'fixed' ? 'fixed' : 'absolute',
+    cx
+  )}
   class:invisible={!$style}
   style:top={$style?.top}
   style:left={$style?.left}

--- a/packages/core/src/lib/floating/index.ts
+++ b/packages/core/src/lib/floating/index.ts
@@ -1,10 +1,3 @@
-export {
-  floatingStyle,
-  type FloatingPlacement,
-  type FloatingReferenceElement,
-  type FloatingStyleStore,
-  type FloatingStyle,
-} from './floating-style';
-
+export * from './floating-style';
 export * from './floating-size';
 export { default as Floating } from './floating.svelte';

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -14,15 +14,7 @@ export {
   type ContextMenuItemVariant,
 } from './context-menu';
 
-export {
-  floatingStyle,
-  Floating,
-  type FloatingPlacement,
-  type FloatingReferenceElement,
-  type FloatingStyleStore,
-  type FloatingStyle,
-} from './floating';
-
+export * from './floating';
 export * from './icon';
 
 export {


### PR DESCRIPTION
## Overview

We have floating menus that must not overflow the screen. This PR adds various options to our `floating-ui` wrappers to allow the height of a floating element to be constrained.

## Change log

- Add `limitHeight` helper to construct `size` options to limit an element's height to the available space, less some margin
- Allow a floating element to use the `position: fixed` strategy, in case a floating element needs to break out of a clipping element
    - This happens when a floating element is floating off another floating element with a constrained height with `overflow` set
- Add a `<Floating>` component to take extra classnames

## Review requests

I've got this branch `pnpm link`'d up to my local dev environment to verify this works as intended. Code review should suffice here 