### PR TITLE
Remove legacy playwright tests from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,6 @@ jobs:
       - name: Install 🔧
         uses: viamrobotics/js-config/.github/actions/setup@0006127efb3f62669f662ca31c555a49a034935e
 
-      - name: Install Playwright Browsers
-        run: pnpm -C packages/legacy playwright-install --with-deps
-
       - name: Build 🏗️
         run: pnpm run build
 
@@ -51,14 +48,6 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: packages/storybook/prime
-
-      - name: Upload Playwright test artifacts
-        uses: actions/upload-artifact@v3
-        if: ${{ always() }}
-        with:
-          name: playwright-report
-          path: packages/legacy/playwright-report/
-          retention-days: 30
 
   deploy-npm:
     if: ${{ github.repository == 'viamrobotics/prime' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
     "build": "pnpm -r --aggregate-output build",
     "check": "pnpm -r --aggregate-output check",
     "format": "pnpm -r --aggregate-output format",
-    "test": "pnpm -r --aggregate-output test"
+    "test": "pnpm -r --aggregate-output --filter \\!./packages/legacy test"
   }
 }


### PR DESCRIPTION
As discussed in Slack. We don't contribute to `legacy` anymore, so this will give us a significant CI speedup