### PR TITLE
allow click through

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.105",
+  "version": "0.0.106",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/select/select.svelte
+++ b/packages/core/src/lib/select/select.svelte
@@ -83,7 +83,7 @@ $: errorClasses =
     <slot />
   </select>
   <span
-    class={cx('absolute right-2 top-1.5 text-gray-6 transition', {
+    class={cx('pointer-events-none absolute right-2 top-1.5 text-gray-6 transition', {
       'peer-active:rotate-180': !disabled,
     })}
   >

--- a/packages/core/src/lib/select/select.svelte
+++ b/packages/core/src/lib/select/select.svelte
@@ -83,9 +83,12 @@ $: errorClasses =
     <slot />
   </select>
   <span
-    class={cx('pointer-events-none absolute right-2 top-1.5 text-gray-6 transition', {
-      'peer-active:rotate-180': !disabled,
-    })}
+    class={cx(
+      'pointer-events-none absolute right-2 top-1.5 text-gray-6 transition',
+      {
+        'peer-active:rotate-180': !disabled,
+      }
+    )}
   >
     <Icon name="chevron-down" />
   </span>


### PR DESCRIPTION
Clicking on the icon currently makes the arrow spin and doesn't show options. This allows to click through said icon.

Note that the icon does not spin but I don't think it's worth fixing as we're replacing this with a library. Please advise?

https://github.com/viamrobotics/prime/assets/17263/26c271b8-b1cf-4dd6-9be2-54755edfecd1


https://github.com/viamrobotics/prime/assets/17263/e7017acf-8259-45bb-8aca-5ac262c17fb0



