### PR TITLE
APP-4361: remove tooltips from flow when invisible

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.112",
+  "version": "0.0.113",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/input/__tests__/restricted-text-input.spec.ts
+++ b/packages/core/src/lib/input/__tests__/restricted-text-input.spec.ts
@@ -99,14 +99,14 @@ describe('Restricted Text Input', () => {
     // Type a single invalid character, which shows the tooltip but does not wiggle
     await user.type(input, 'a');
 
-    expect(tooltip).not.toHaveClass('invisible');
+    expect(tooltip).not.toHaveClass('hidden');
     expect(tooltip).not.toHaveClass('animate-wiggle');
-    await waitFor(() => expect(tooltip).toHaveClass('invisible'));
+    await waitFor(() => expect(tooltip).toHaveClass('hidden'));
 
     // Type multiple invalid characters, which shows the tooltip and wiggles
     await user.type(input, 'aa');
 
-    expect(tooltip).not.toHaveClass('invisible');
+    expect(tooltip).not.toHaveClass('hidden');
     expect(tooltip).toHaveClass('animate-wiggle');
     await waitFor(() => expect(tooltip).not.toHaveClass('animate-wiggle'));
   });

--- a/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
+++ b/packages/core/src/lib/tooltip/__tests__/tooltip.spec.ts
@@ -12,7 +12,7 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip');
 
     expect(target).toBeInTheDocument();
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
   });
 
   it('passes the tooltip ID to the target slot', () => {
@@ -34,15 +34,15 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip');
 
     // tooltip should initially be invisible before styles calculate
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
     // then it should become visible
     await waitFor(() => expect(tooltip).not.toHaveClass('invisible'));
 
     await user.hover(target);
-    expect(tooltip).not.toHaveClass('invisible');
+    expect(tooltip).not.toHaveClass('hidden');
 
     await user.unhover(target);
-    expect(tooltip).not.toHaveClass('invisible');
+    expect(tooltip).not.toHaveClass('hidden');
   });
 
   it('does not render the tooltip when state is invisible', async () => {
@@ -54,14 +54,14 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip');
 
     // tooltip should initially be invisible before styles calculate
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
 
     // tooltip should stay invisible despite hover state
     await user.hover(target);
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
 
     await user.unhover(target);
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
   });
 
   it('shows/hides the tooltip on mouse enter/exit', async () => {
@@ -73,10 +73,10 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip');
 
     await user.hover(target);
-    expect(tooltip).not.toHaveClass('invisible');
+    expect(tooltip).not.toHaveClass('hidden');
 
     await user.unhover(target);
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
   });
 
   it('shows the tooltip on mouse enter after a delay', async () => {
@@ -88,7 +88,7 @@ describe('Tooltip', () => {
     const tooltip = screen.getByRole('tooltip');
 
     await user.hover(target);
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
     await waitFor(() => expect(tooltip).not.toHaveClass('invisible'));
   });
 
@@ -100,10 +100,10 @@ describe('Tooltip', () => {
 
     await userEvent.tab();
     expect(target).toHaveFocus();
-    expect(tooltip).not.toHaveClass('invisible');
+    expect(tooltip).not.toHaveClass('hidden');
 
     await userEvent.tab();
     expect(target).not.toHaveFocus();
-    expect(tooltip).toHaveClass('invisible');
+    expect(tooltip).toHaveClass('hidden');
   });
 });

--- a/packages/core/src/lib/tooltip/tooltip-text.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-text.svelte
@@ -39,7 +39,7 @@ $: style.register({
   bind:this={floatingElement}
   {id}
   role="tooltip"
-  class:invisible={!$isVisible || !$style}
+  class:hidden={!$isVisible || !$style}
   style:top={$style?.top}
   style:left={$style?.left}
   class={cx(


### PR DESCRIPTION
## Overview

This PR fixes a frustrating layout issue caused by #509 

- The position of invisible tooltips is not recalculated on screen resize etc.
- Tooltips are hidden via `visibility: invisible`, so they are still in the flow
- If the screen is resized, tooltips will remain where they are, creating overflow

## Change log

- Swap `visibility: invisible` for `display: hidden` for invisible tooltips

## Accessibility issues

Both `visibility: invisible` and `display: hidden` are invisible to screen-readers. For tooltips that provide `aria-describedby` or `aria-labelledby`, this may not be optimal. Experimenting with VoiceOver seems to indicate that we have a lot of accessibility tuning to do with tooltips, anyway

## Review requests

Try to break this! Throwing a `display: hidden` on there means that we rely on the `display: hidden` getting removed from the tooltip _before_ floating-ui's `calculateStyle`. I'm pretty sure that our derived store chain ensures this is the case, but keep an eye out