### PR TITLE
App 4656 add ability to truncate breadcrumb items and pills

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.118",
+  "version": "0.0.119",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/breadcrumbs.svelte
+++ b/packages/core/src/lib/breadcrumbs.svelte
@@ -27,7 +27,7 @@ export { extraClasses as cx };
   )}
 >
   {#each crumbs as crumb, index (crumb)}
-    <small class="text-xs">
+    <small class="truncate text-xs">
       {crumb}
     </small>
     {#if index !== crumbs.length - 1}

--- a/packages/core/src/lib/pill.svelte
+++ b/packages/core/src/lib/pill.svelte
@@ -69,9 +69,7 @@ const handleRemove = () => {
       size="sm"
     />
   {/if}
-  <span>
-    {value}
-  </span>
+  <span class="truncate">{value}</span>
   {#if !readonly && removable}
     <button
       type="button"

--- a/packages/core/src/lib/tooltip/tooltip-text.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-text.svelte
@@ -57,7 +57,7 @@ $: style.register({
   />
 
   <div
-    class="flex items-center gap-1 bg-gray-9 px-2 py-1 text-left text-xs text-white"
+    class="flex items-center gap-1 bg-gray-9 px-2 py-1 text-left text-xs text-white break-all"
   >
     <slot />
   </div>

--- a/packages/core/src/lib/tooltip/tooltip-text.svelte
+++ b/packages/core/src/lib/tooltip/tooltip-text.svelte
@@ -57,7 +57,7 @@ $: style.register({
   />
 
   <div
-    class="flex items-center gap-1 bg-gray-9 px-2 py-1 text-left text-xs text-white break-all"
+    class="flex items-center gap-1 break-all bg-gray-9 px-2 py-1 text-left text-xs text-white"
   >
     <slot />
   </div>

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1616,7 +1616,9 @@ const onHoverDelayMsInput = (event: Event) => {
   <div class="flex flex-wrap items-start gap-4">
     <Tooltip let:tooltipID>
       <p aria-describedby={tooltipID}>This element has a top tooltip.</p>
-      <p slot="description">ThisIsTheTooltipTextWithoutSpacesOrHyphensForTestingPurposes</p>
+      <p slot="description">
+        ThisIsTheTooltipTextWithoutSpacesOrHyphensForTestingPurposes
+      </p>
     </Tooltip>
 
     <Tooltip

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1616,7 +1616,7 @@ const onHoverDelayMsInput = (event: Event) => {
   <div class="flex flex-wrap items-start gap-4">
     <Tooltip let:tooltipID>
       <p aria-describedby={tooltipID}>This element has a top tooltip.</p>
-      <p slot="description">This is the tooltip text!</p>
+      <p slot="description">ThisIsTheTooltipTextWithoutSpacesOrHyphensForTestingPurposes</p>
     </Tooltip>
 
     <Tooltip


### PR DESCRIPTION
- Tailwind's `truncate` class added
- Fix issue where long tooltips get clipped in favor of wrapping
