### PR TITLE
add optional for attribute to Label component

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.119",
+  "version": "0.0.120",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/label.svelte
+++ b/packages/core/src/lib/label.svelte
@@ -31,6 +31,10 @@ export let required = false;
 /** Whether or not the label should render as disabled */
 export let disabled = false;
 
+/** The input the label describes */
+let htmlFor: string | undefined = undefined;
+export { htmlFor as for };
+
 /** Additional detail text to render after the default slot. */
 export let detail = '';
 
@@ -48,6 +52,7 @@ export { extraClasses as cx };
     },
     extraClasses
   )}
+  for={htmlFor}
 >
   <span
     class={cx('flex text-xs', {

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1064,6 +1064,20 @@ const onHoverDelayMsInput = (event: Event) => {
         name="name"
       />
     </Label>
+
+    <div>
+      <Label
+        for="targetID"
+        cx="whitespace-nowrap"
+      >
+        For attribute example
+      </Label>
+      <Input
+        cx="max-w-[70px]"
+        id="targetID"
+        name="name"
+      />
+    </div>
   </div>
 
   <!-- Notify -->


### PR DESCRIPTION
Add option to add `for` attribute for use with inputs that are not children. This allows for independent click targets and avoids bug as shown here.

![image](https://github.com/viamrobotics/prime/assets/17263/9026d846-9628-410f-ac39-f69f5eec12dc)
