### PR TITLE
[APP-5332] [APP-4147]: Add 4 more toast styles and update storybook

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.125",
+  "version": "0.0.126",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/button/button.svelte
+++ b/packages/core/src/lib/button/button.svelte
@@ -41,6 +41,11 @@ export let icon: IconName | undefined = undefined;
 /** The width of the button. */
 export let width: 'full' | 'default' = 'default';
 
+/** The height of the button. */
+export let height: 'fixed' | 'default' = 'default';
+
+export let textSize: 'text-sm' | 'text-xs' = 'text-xs';
+
 /** Shows progress indicator. Determinite progress is a @TODO */
 export let progress: 'indeterminate' | number | undefined = undefined;
 
@@ -56,7 +61,7 @@ $: handleDisabled = preventHandler(disabled);
   {title}
   aria-disabled={disabled ? true : undefined}
   class={cx(
-    'inline-flex select-none items-center justify-center gap-1.5 whitespace-nowrap border py-1.5 text-xs',
+    'inline-flex select-none items-center justify-center gap-1.5 whitespace-nowrap border',
     {
       'flex w-full': width === 'full',
       'inline-flex': width !== 'full',
@@ -77,6 +82,8 @@ $: handleDisabled = preventHandler(disabled);
       'border-danger-medium bg-danger-light text-danger-dark hover:bg-[#f5dfdc] active:bg-[#f6d7d3]':
         variant === 'outline-danger' && !disabled,
     },
+    height === 'fixed' ? 'h-7.5' : 'py-1.5',
+    textSize,
     extraClasses
   )}
   {...$$restProps}

--- a/packages/core/src/lib/button/icon-button.svelte
+++ b/packages/core/src/lib/button/icon-button.svelte
@@ -11,7 +11,7 @@ For user triggered actions.
 
 <script lang="ts">
 import cx from 'classnames';
-import { Icon, type IconName } from '$lib';
+import { Icon, type IconName } from '$lib/icon';
 import { preventHandler } from '$lib/prevent-handler';
 import Progress from '$lib/progress/progress.svelte';
 
@@ -28,7 +28,7 @@ export let disabled = false;
 export let type: 'button' | 'submit' | 'reset' = 'button';
 
 /** The communicated action type to the user. */
-export let variant: 'primary' | 'secondary' | 'danger' = 'primary';
+export let variant: 'primary' | 'secondary' | 'danger' | 'ghost' = 'primary';
 
 /** Shows progress indicator. Determinite progress is a @TODO */
 export let progress: 'indeterminate' | number | undefined = undefined;
@@ -47,11 +47,12 @@ $: handleDisabled = preventHandler(disabled);
   class={cx(
     'inline-flex h-7.5 w-7.5 select-none items-center justify-center whitespace-nowrap',
     {
-      'text-gray-6 hover:border-medium hover:bg-medium active:bg-gray-2':
-        !disabled,
+      'text-gray-6': !disabled,
       'cursor-not-allowed text-gray-4': disabled,
-      'hover:text-gray-7 active:text-gray-8':
+      'hover:border-medium hover:bg-medium hover:text-gray-7 active:bg-gray-2 active:text-gray-8':
         variant === 'primary' && !disabled,
+      'border-transparent text-default hover:bg-ghost-light active:border-ghost-medium active:bg-ghost-medium':
+        variant === 'ghost' && !disabled,
       'border-light bg-light hover:border-medium hover:bg-medium active:border-medium active:bg-gray-2':
         variant === 'secondary' && !disabled,
       'hover:bg-danger-dark hover:bg-opacity-[0.08] hover:text-danger-dark active:bg-[rgba(190,53,54,0.16)] active:text-danger-dark':

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -28,7 +28,7 @@ describe('toast', () => {
 
     const status = screen.getByRole('status');
     const toast = within(status).getByRole('listitem');
-    const icon = screen.getByRole('img', { name: /success/iu });
+    const icon = screen.getByRole('img', { name: /check-circle/iu });
 
     within(toast).getByRole('button', { name: /dismiss/iu });
     expect(toast).toHaveTextContent(/This is a success toast message/iu);
@@ -51,7 +51,9 @@ describe('toast', () => {
 
     const status = screen.getByRole('status');
     const toast = within(status).getByRole('listitem');
-    const actionButton = screen.getByText(/action text/iu);
+    const actionButton = screen.getByRole('button', {
+      name: /action text/iu,
+    });
     await user.click(actionButton);
 
     expect(toast).toHaveTextContent(/action text/iu);

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -19,7 +19,7 @@ describe('toast', () => {
     screen.getByRole('status', { name: 'Toasts' });
   });
 
-  it('should display a dismissable toast', async () => {
+  it('should display a dismissible toast', async () => {
     await act(() => {
       context.toast({
         message: 'This is a success toast message',

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -51,9 +51,7 @@ describe('toast', () => {
 
     const status = screen.getByRole('status');
     const toast = within(status).getByRole('listitem');
-    const actionButton = screen.getByRole('button', {
-      name: /perform action/iu,
-    });
+    const actionButton = screen.getByText(/action text/iu);
     await user.click(actionButton);
 
     expect(toast).toHaveTextContent(/action text/iu);

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -19,7 +19,7 @@ describe('toast', () => {
     screen.getByRole('status', { name: 'Toasts' });
   });
 
-  it('should display a toast with success variant with correct classes and label', async () => {
+  it('should display a dismissable toast', async () => {
     await act(() => {
       context.toast({
         message: 'This is a success toast message',
@@ -34,74 +34,6 @@ describe('toast', () => {
     within(toast).getByRole('button', { name: /dismiss/iu });
     expect(toast).toHaveTextContent(/This is a success toast message/iu);
     expect(icon).toHaveClass('text-success-dark');
-  });
-
-  it('should display a toast with info variant with correct classes and label', async () => {
-    await act(() => {
-      context.toast({
-        message: 'This is a info toast message',
-        variant: ToastVariant.Info,
-      });
-    });
-
-    const status = screen.getByRole('status');
-    const toast = within(status).getByRole('listitem');
-    const icon = screen.getByRole('img', { name: /info/iu });
-
-    within(toast).getByRole('button', { name: /dismiss/iu });
-    expect(toast).toHaveTextContent(/This is a info toast message/iu);
-    expect(icon).toHaveClass('text-info-dark');
-  });
-
-  it('should display a toast with warning variant with correct classes and label', async () => {
-    await act(() => {
-      context.toast({
-        message: 'This is a warning toast message',
-        variant: ToastVariant.Warning,
-      });
-    });
-
-    const status = screen.getByRole('status');
-    const toast = within(status).getByRole('listitem');
-    const icon = screen.getByRole('img', { name: /warning/iu });
-
-    within(toast).getByRole('button', { name: /dismiss/iu });
-    expect(toast).toHaveTextContent(/This is a warning toast message/iu);
-    expect(icon).toHaveClass('text-warning-bright');
-  });
-
-  it('should display a toast with danger variant with correct classes and label', async () => {
-    await act(() => {
-      context.toast({
-        message: 'This is a danger toast message',
-        variant: ToastVariant.Danger,
-      });
-    });
-
-    const status = screen.getByRole('status');
-    const toast = within(status).getByRole('listitem');
-    const icon = screen.getByRole('img', { name: /danger/iu });
-
-    within(toast).getByRole('button', { name: /dismiss/iu });
-    expect(toast).toHaveTextContent(/This is a danger toast message/iu);
-    expect(icon).toHaveClass('text-danger-dark');
-  });
-
-  it('should display a toast with neutral variant with correct classes and label', async () => {
-    await act(() => {
-      context.toast({
-        message: 'This is a neutral toast message',
-        variant: ToastVariant.Neutral,
-      });
-    });
-
-    const status = screen.getByRole('status');
-    const toast = within(status).getByRole('listitem');
-    const icon = screen.getByRole('img', { name: /neutral/iu });
-
-    within(toast).getByRole('button', { name: /dismiss/iu });
-    expect(toast).toHaveTextContent(/This is a neutral toast message/iu);
-    expect(icon).toHaveClass('text-gray-7');
   });
 
   it('should display a toast with an action button when action is provided', async () => {
@@ -128,4 +60,25 @@ describe('toast', () => {
     expect(toast).toHaveTextContent(/action text/iu);
     expect(actionHandler).toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      variant: ToastVariant.Success,
+      expectedName: /success/iu,
+      expectedColor: 'text-success-dark',
+    },
+    // ...
+  ])('displays correct icon for %variant', async ({
+    variant,
+    expectedName,
+    expectedColor,
+  }) => {
+    await act(() => context.toast({ message: 'Hello world', variant }));
+  
+    const status = screen.getByRole('status');
+    const toast = within(status).getByRole('listitem');
+    const icon = within(toast).getByRole('img', { name: expectedName });
+  
+    expect(icon).toHaveClass(expectedColor);
+  })
 });

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -67,7 +67,26 @@ describe('toast', () => {
       expectedName: /success/iu,
       expectedColor: 'text-success-dark',
     },
-    // ...
+    {
+      variant: ToastVariant.Info,
+      expectedName: /info/iu,
+      expectedColor: 'text-info-dark',
+    },
+    {
+      variant: ToastVariant.Warning,
+      expectedName: /warning/iu,
+      expectedColor: 'text-warning-bright',
+    },
+    {
+      variant: ToastVariant.Danger,
+      expectedName: /danger/iu,
+      expectedColor: 'text-danger-dark',
+    },
+    {
+      variant: ToastVariant.Neutral,
+      expectedName: /neutral/iu,
+      expectedColor: 'text-gray-7',
+    },
   ])(
     'displays correct icon for %variant',
     async ({ variant, expectedName, expectedColor }) => {

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -23,7 +23,7 @@ describe('toast', () => {
     await act(() => {
       context.toast({
         message: 'This is a success toast message',
-        variant: ToastVariant.Success
+        variant: ToastVariant.Success,
       });
     });
 
@@ -40,7 +40,7 @@ describe('toast', () => {
     await act(() => {
       context.toast({
         message: 'This is a info toast message',
-        variant: ToastVariant.Info
+        variant: ToastVariant.Info,
       });
     });
 
@@ -57,7 +57,7 @@ describe('toast', () => {
     await act(() => {
       context.toast({
         message: 'This is a warning toast message',
-        variant: ToastVariant.Warning
+        variant: ToastVariant.Warning,
       });
     });
 
@@ -74,7 +74,7 @@ describe('toast', () => {
     await act(() => {
       context.toast({
         message: 'This is a danger toast message',
-        variant: ToastVariant.Danger
+        variant: ToastVariant.Danger,
       });
     });
 
@@ -91,7 +91,7 @@ describe('toast', () => {
     await act(() => {
       context.toast({
         message: 'This is a neutral toast message',
-        variant: ToastVariant.Neutral
+        variant: ToastVariant.Neutral,
       });
     });
 

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -19,20 +19,89 @@ describe('toast', () => {
     screen.getByRole('status', { name: 'Toasts' });
   });
 
-  it('should display a dismissible toast', async () => {
+  it('should display a toast with success variant with correct classes and label', async () => {
     await act(() => {
       context.toast({
         message: 'This is a success toast message',
+        variant: ToastVariant.Success
       });
     });
 
     const status = screen.getByRole('status');
     const toast = within(status).getByRole('listitem');
-    const icon = screen.getByRole('img', { name: /check-circle/iu });
+    const icon = screen.getByRole('img', { name: /success/iu });
 
     within(toast).getByRole('button', { name: /dismiss/iu });
     expect(toast).toHaveTextContent(/This is a success toast message/iu);
     expect(icon).toHaveClass('text-success-dark');
+  });
+
+  it('should display a toast with info variant with correct classes and label', async () => {
+    await act(() => {
+      context.toast({
+        message: 'This is a info toast message',
+        variant: ToastVariant.Info
+      });
+    });
+
+    const status = screen.getByRole('status');
+    const toast = within(status).getByRole('listitem');
+    const icon = screen.getByRole('img', { name: /info/iu });
+
+    within(toast).getByRole('button', { name: /dismiss/iu });
+    expect(toast).toHaveTextContent(/This is a info toast message/iu);
+    expect(icon).toHaveClass('text-info-dark');
+  });
+
+  it('should display a toast with warning variant with correct classes and label', async () => {
+    await act(() => {
+      context.toast({
+        message: 'This is a warning toast message',
+        variant: ToastVariant.Warning
+      });
+    });
+
+    const status = screen.getByRole('status');
+    const toast = within(status).getByRole('listitem');
+    const icon = screen.getByRole('img', { name: /warning/iu });
+
+    within(toast).getByRole('button', { name: /dismiss/iu });
+    expect(toast).toHaveTextContent(/This is a warning toast message/iu);
+    expect(icon).toHaveClass('text-warning-bright');
+  });
+
+  it('should display a toast with danger variant with correct classes and label', async () => {
+    await act(() => {
+      context.toast({
+        message: 'This is a danger toast message',
+        variant: ToastVariant.Danger
+      });
+    });
+
+    const status = screen.getByRole('status');
+    const toast = within(status).getByRole('listitem');
+    const icon = screen.getByRole('img', { name: /danger/iu });
+
+    within(toast).getByRole('button', { name: /dismiss/iu });
+    expect(toast).toHaveTextContent(/This is a danger toast message/iu);
+    expect(icon).toHaveClass('text-danger-dark');
+  });
+
+  it('should display a toast with neutral variant with correct classes and label', async () => {
+    await act(() => {
+      context.toast({
+        message: 'This is a neutral toast message',
+        variant: ToastVariant.Neutral
+      });
+    });
+
+    const status = screen.getByRole('status');
+    const toast = within(status).getByRole('listitem');
+    const icon = screen.getByRole('img', { name: /neutral/iu });
+
+    within(toast).getByRole('button', { name: /dismiss/iu });
+    expect(toast).toHaveTextContent(/This is a neutral toast message/iu);
+    expect(icon).toHaveClass('text-gray-7');
   });
 
   it('should display a toast with an action button when action is provided', async () => {

--- a/packages/core/src/lib/toast/__tests__/toast.spec.ts
+++ b/packages/core/src/lib/toast/__tests__/toast.spec.ts
@@ -68,17 +68,16 @@ describe('toast', () => {
       expectedColor: 'text-success-dark',
     },
     // ...
-  ])('displays correct icon for %variant', async ({
-    variant,
-    expectedName,
-    expectedColor,
-  }) => {
-    await act(() => context.toast({ message: 'Hello world', variant }));
-  
-    const status = screen.getByRole('status');
-    const toast = within(status).getByRole('listitem');
-    const icon = within(toast).getByRole('img', { name: expectedName });
-  
-    expect(icon).toHaveClass(expectedColor);
-  })
+  ])(
+    'displays correct icon for %variant',
+    async ({ variant, expectedName, expectedColor }) => {
+      await act(() => context.toast({ message: 'Hello world', variant }));
+
+      const status = screen.getByRole('status');
+      const toast = within(status).getByRole('listitem');
+      const icon = within(toast).getByRole('img', { name: expectedName });
+
+      expect(icon).toHaveClass(expectedColor);
+    }
+  );
 });

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -5,7 +5,11 @@ import cx from 'classnames';
 import Button from '$lib/button/button.svelte';
 import { Icon } from '$lib/icon';
 import IconButton from '$lib/button/icon-button.svelte';
-import { DisplayDetailsByVariant, ToastVariant, type ToastVariantType } from './variants';
+import {
+  DisplayDetailsByVariant,
+  ToastVariant,
+  type ToastVariantType,
+} from './variants';
 
 /** The message displayed on the toast */
 export let message: string;
@@ -18,7 +22,7 @@ export let action: { text: string; handler: () => unknown } | undefined =
 /** The severity of the notification you want to show users*/
 export let variant: ToastVariantType = ToastVariant.Success;
 
-const displayDetails = DisplayDetailsByVariant[variant]
+const displayDetails = DisplayDetailsByVariant[variant];
 
 /** Additional CSS classes to pass to the banner. */
 let extraClasses: cx.Argument = '';

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -5,7 +5,7 @@ import cx from 'classnames';
 import Button from '$lib/button/button.svelte';
 import { Icon } from '$lib/icon';
 import IconButton from '$lib/button/icon-button.svelte';
-import { ToastVariant, type ToastVariantType } from './variants';
+import { DisplayDetailsByVariant, ToastVariant, type ToastVariantType } from './variants';
 
 /** The message displayed on the toast */
 export let message: string;
@@ -17,6 +17,8 @@ export let action: { text: string; handler: () => unknown } | undefined =
 
 /** The severity of the notification you want to show users*/
 export let variant: ToastVariantType = ToastVariant.Success;
+
+const displayDetails = DisplayDetailsByVariant[variant]
 
 /** Additional CSS classes to pass to the banner. */
 let extraClasses: cx.Argument = '';
@@ -32,11 +34,11 @@ export { extraClasses as cx };
   <div class="mr-4 flex gap-2">
     <Icon
       size="lg"
-      name={variant.icon}
-      cx={variant.iconClasses}
+      name={displayDetails.icon}
+      cx={displayDetails.iconClasses}
       role="img"
       aria-hidden={false}
-      aria-label={variant.label}
+      aria-label={displayDetails.label}
     />
     <p class="truncate">{message}</p>
   </div>

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -30,14 +30,14 @@ export { extraClasses as cx };
   )}
 >
   <div class="mr-4 flex gap-2">
-      <Icon
-        size="lg"
-        name={variant.icon}
-        cx={variant.iconClasses}
-        role="img"
-        aria-hidden={false}
-        aria-label={variant.label}
-      />
+    <Icon
+      size="lg"
+      name={variant.icon}
+      cx={variant.iconClasses}
+      role="img"
+      aria-hidden={false}
+      aria-label={variant.label}
+    />
     <p class="truncate">{message}</p>
   </div>
 

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -36,6 +36,7 @@ export { extraClasses as cx };
         cx={variant.iconClasses}
         role="img"
         aria-hidden={false}
+        aria-label={variant.label}
       />
     <p class="truncate">{message}</p>
   </div>

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -2,8 +2,10 @@
 
 <script lang="ts">
 import cx from 'classnames';
-import { Icon, IconButton } from '$lib';
-import { iconName, iconClasses } from './variants';
+import Button from '$lib/button/button.svelte';
+import { Icon, type IconName } from '$lib/icon';
+import IconButton from '$lib/button/icon-button.svelte';
+import { ToastVariant, type ToastVariantType } from './variants';
 
 /** The message displayed on the toast */
 export let message: string;
@@ -13,41 +15,80 @@ export let dismiss: () => void;
 export let action: { text: string; handler: () => unknown } | undefined =
   undefined;
 
+/** The severity of the notification you want to show users*/
+export let variant: ToastVariantType = 'success';
+
 /** Additional CSS classes to pass to the banner. */
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
+
+let icon: IconName | null = null;
+let iconClasses = '';
+$: {
+  switch (variant) {
+    case ToastVariant.Info: {
+      icon = 'information-outline';
+      iconClasses = 'text-info-dark';
+      break;
+    }
+    case ToastVariant.Warning: {
+      icon = 'alert';
+      iconClasses = 'text-warning-bright';
+      break;
+    }
+    case ToastVariant.Danger: {
+      icon = 'alert-circle';
+      iconClasses = 'text-danger-dark';
+      break;
+    }
+    case ToastVariant.Success: {
+      icon = 'check-circle';
+      iconClasses = 'text-success-dark';
+      break;
+    }
+    case ToastVariant.Neutral: {
+      icon = 'domain';
+      iconClasses = 'text-gray-7';
+    }
+  }
+}
 </script>
 
 <div
   class={cx(
-    'relative flex h-10 w-max max-w-[480px] items-center border bg-medium pl-3 pr-1 text-sm',
+    'relative flex h-10 w-max max-w-[480px] items-center border border-medium bg-medium pl-3 pr-1 text-sm text-default shadow-sm',
     extraClasses
   )}
 >
   <div class="mr-4 flex gap-2">
-    <Icon
-      size="lg"
-      name={iconName}
-      cx={iconClasses}
-      role="img"
-      aria-hidden={false}
-      aria-label="success"
-    />
+    {#if icon}
+      <Icon
+        size="lg"
+        name={icon}
+        cx={iconClasses}
+        role="img"
+        aria-hidden={false}
+        aria-label="success"
+      />
+    {/if}
 
     <p class="truncate">{message}</p>
   </div>
 
-  <div class="flex gap-1">
+  <div class="flex">
     {#if action}
-      <button
+      <Button
+        height="fixed"
+        textSize="text-sm"
+        variant="ghost"
         type="button"
         on:click={action.handler}
-        aria-label="Perform action"
       >
-        <span class="text-sm font-medium hover:underline">{action.text}</span>
-      </button>
+        {action.text}
+      </Button>
     {/if}
     <IconButton
+      variant="ghost"
       cx="text-gray-7"
       label="Dismiss toast"
       icon="close"

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
 import cx from 'classnames';
 import Button from '$lib/button/button.svelte';
-import { Icon, type IconName } from '$lib/icon';
+import { Icon } from '$lib/icon';
 import IconButton from '$lib/button/icon-button.svelte';
 import { ToastVariant, type ToastVariantType } from './variants';
 
@@ -16,42 +16,11 @@ export let action: { text: string; handler: () => unknown } | undefined =
   undefined;
 
 /** The severity of the notification you want to show users*/
-export let variant: ToastVariantType = 'success';
+export let variant: ToastVariantType = ToastVariant.Success;
 
 /** Additional CSS classes to pass to the banner. */
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
-
-let icon: IconName | null = null;
-let iconClasses = '';
-$: {
-  switch (variant) {
-    case ToastVariant.Info: {
-      icon = 'information-outline';
-      iconClasses = 'text-info-dark';
-      break;
-    }
-    case ToastVariant.Warning: {
-      icon = 'alert';
-      iconClasses = 'text-warning-bright';
-      break;
-    }
-    case ToastVariant.Danger: {
-      icon = 'alert-circle';
-      iconClasses = 'text-danger-dark';
-      break;
-    }
-    case ToastVariant.Success: {
-      icon = 'check-circle';
-      iconClasses = 'text-success-dark';
-      break;
-    }
-    case ToastVariant.Neutral: {
-      icon = 'domain';
-      iconClasses = 'text-gray-7';
-    }
-  }
-}
 </script>
 
 <div
@@ -61,17 +30,13 @@ $: {
   )}
 >
   <div class="mr-4 flex gap-2">
-    {#if icon}
       <Icon
         size="lg"
-        name={icon}
-        cx={iconClasses}
+        name={variant.icon}
+        cx={variant.iconClasses}
         role="img"
         aria-hidden={false}
-        aria-label="success"
       />
-    {/if}
-
     <p class="truncate">{message}</p>
   </div>
 

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -32,6 +32,6 @@ export const DisplayDetailsByVariant = {
     iconClasses: 'text-gray-7',
     label: 'neutral',
   },
-};
+} as const;
 
 export type ToastVariantType = (typeof ToastVariant)[keyof typeof ToastVariant];

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -1,29 +1,37 @@
 export const ToastVariant = {
-  Info: {
+  Info: 'info',
+  Warning: 'warning',
+  Danger: 'danger',
+  Success: 'success',
+  Neutral: 'neutral',
+} as const;
+
+export const DisplayDetailsByVariant = {
+  [ToastVariant.Info]: {
     icon: 'information-outline',
     iconClasses: 'text-info-dark',
     label: 'info',
   },
-  Warning: {
+  [ToastVariant.Warning]: {
     icon: 'alert',
     iconClasses: 'text-warning-bright',
     label: 'warning',
   },
-  Danger: {
+  [ToastVariant.Danger]: {
     icon: 'alert-circle',
     iconClasses: 'text-danger-dark',
     label: 'danger',
   },
-  Success: {
+  [ToastVariant.Success]: {
     icon: 'check-circle',
     iconClasses: 'text-success-dark',
     label: 'success',
   },
-  Neutral: {
+  [ToastVariant.Neutral]: {
     icon: 'domain',
     iconClasses: 'text-gray-7',
     label: 'neutral',
-  },
-} as const;
+  }
+}
 
 export type ToastVariantType = (typeof ToastVariant)[keyof typeof ToastVariant];

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -1,9 +1,24 @@
 export const ToastVariant = {
-  Info: 'info',
-  Warning: 'warning',
-  Danger: 'danger',
-  Success: 'success',
-  Neutral: 'neutral',
+  Info: {
+    icon: 'information-outline',
+    iconClasses: 'text-info-dark',
+  },
+  Warning: {
+    icon: 'alert',
+    iconClasses: 'text-warning-bright',
+  },
+  Danger: {
+    icon: 'alert-circle',
+    iconClasses: 'text-danger-dark',
+  },
+  Success: {
+    icon: 'check-circle',
+    iconClasses: 'text-success-dark',
+  },
+  Neutral: {
+    icon: 'domain',
+    iconClasses: 'text-gray-7',
+  },
 } as const;
 
 export type ToastVariantType = (typeof ToastVariant)[keyof typeof ToastVariant];

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -2,22 +2,27 @@ export const ToastVariant = {
   Info: {
     icon: 'information-outline',
     iconClasses: 'text-info-dark',
+    label: 'info',
   },
   Warning: {
     icon: 'alert',
     iconClasses: 'text-warning-bright',
+    label: 'warning',
   },
   Danger: {
     icon: 'alert-circle',
     iconClasses: 'text-danger-dark',
+    label: 'danger',
   },
   Success: {
     icon: 'check-circle',
     iconClasses: 'text-success-dark',
+    label: 'success',
   },
   Neutral: {
     icon: 'domain',
     iconClasses: 'text-gray-7',
+    label: 'neutral',
   },
 } as const;
 

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -1,10 +1,9 @@
-import type { IconName } from '$lib/icon/icons';
-
 export const ToastVariant = {
+  Info: 'info',
+  Warning: 'warning',
+  Danger: 'danger',
   Success: 'success',
+  Neutral: 'neutral',
 } as const;
-
-export const iconName: IconName = 'check-circle';
-export const iconClasses = 'text-success-dark';
 
 export type ToastVariantType = (typeof ToastVariant)[keyof typeof ToastVariant];

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -31,7 +31,7 @@ export const DisplayDetailsByVariant = {
     icon: 'domain',
     iconClasses: 'text-gray-7',
     label: 'neutral',
-  }
-}
+  },
+};
 
 export type ToastVariantType = (typeof ToastVariant)[keyof typeof ToastVariant];

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -33,7 +33,7 @@ import {
   TableRow,
   ToastBanner,
   ToastContainer,
-  ToastVariantType,
+  ToastVariant,
   ToggleButtons,
   Select,
   SearchableSelect,
@@ -1612,7 +1612,7 @@ const onHoverDelayMsInput = (event: Event) => {
   <div class="flex gap-4">
     <ToastBanner
       message="Test Message"
-      variant=ToastVariantType.Success
+      variant={ ToastVariant.Success }
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1620,7 +1620,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant="info"
+      variant={ ToastVariant.Info }
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1628,7 +1628,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant="danger"
+      variant={ ToastVariant.Danger }
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1636,7 +1636,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant="warning"
+      variant={ ToastVariant.Warning }
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1644,7 +1644,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant="neutral"
+      variant={ ToastVariant.Neutral }
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1654,7 +1654,7 @@ const onHoverDelayMsInput = (event: Event) => {
   <div class="flex gap-4">
     <ToastBanner
       message="Test Message"
-      variant="success"
+      variant={ ToastVariant.Success }
       action={{
         text: 'Undo',
         handler: () => {
@@ -1668,7 +1668,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant="info"
+      variant={ ToastVariant.Info }
       action={{
         text: 'Undo',
         handler: () => {
@@ -1682,7 +1682,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant="danger"
+      variant={ ToastVariant.Danger }
       action={{
         text: 'Undo',
         handler: () => {
@@ -1696,7 +1696,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant="warning"
+      variant={ ToastVariant.Warning }
       action={{
         text: 'Undo',
         handler: () => {
@@ -1718,7 +1718,7 @@ const onHoverDelayMsInput = (event: Event) => {
     <div>
       <Button
         on:click={() => {
-          toast({ message: 'Success', variant: 'success' });
+          toast({ message: 'Success', variant: ToastVariant.Success });
         }}
       >
         Click to show "Success" button
@@ -1727,7 +1727,7 @@ const onHoverDelayMsInput = (event: Event) => {
     <div>
       <Button
         on:click={() => {
-          toast({ message: 'Information', variant: 'info' });
+          toast({ message: 'Information', variant: ToastVariant.Info });
         }}
       >
         Click to show "Info" button
@@ -1736,7 +1736,7 @@ const onHoverDelayMsInput = (event: Event) => {
     <div>
       <Button
         on:click={() => {
-          toast({ message: 'Dangerous', variant: 'danger' });
+          toast({ message: 'Dangerous', variant: ToastVariant.Danger });
         }}
       >
         Click to show "Danger" button
@@ -1745,7 +1745,7 @@ const onHoverDelayMsInput = (event: Event) => {
     <div>
       <Button
         on:click={() => {
-          toast({ message: 'Warning', variant: 'warning' });
+          toast({ message: 'Warning', variant: ToastVariant.Warning });
         }}
       >
         Click to show "Warning" button

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -31,12 +31,15 @@ import {
   TableHeaderCell,
   TableHeader,
   TableRow,
+  ToastBanner,
+  ToastContainer,
   ToggleButtons,
   Select,
   SearchableSelect,
   Multiselect,
   NotificationContainer,
   provideNotify,
+  provideToast,
   useNotify,
   Modal,
   CodeSnippet,
@@ -69,6 +72,7 @@ const handleFloatingMenuChange = (isOpen: boolean) => {
 };
 
 const notify = useNotify();
+const toast = provideToast();
 
 let restrictedValue = '';
 
@@ -1599,6 +1603,153 @@ const onHoverDelayMsInput = (event: Event) => {
       tabs={['Tab 1', 'Tab 2']}
       selected="Tab 2"
     />
+  </div>
+
+  <!-- Toast Banner -->
+  <h1 class="text-2xl">Toast Banner</h1>
+
+  <div class="flex gap-4">
+    <ToastBanner
+      message="Test Message"
+      variant="success"
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+    <ToastBanner
+      message="Test Message"
+      variant="info"
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+    <ToastBanner
+      message="Test Message"
+      variant="danger"
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+    <ToastBanner
+      message="Test Message"
+      variant="warning"
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+    <ToastBanner
+      message="Test Message"
+      variant="neutral"
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+  </div>
+  <div class="flex gap-4">
+    <ToastBanner
+      message="Test Message"
+      variant="success"
+      action={{
+        text: 'Undo',
+        handler: () => {
+          console.log('Clicked action');
+        },
+      }}
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+    <ToastBanner
+      message="Test Message"
+      variant="info"
+      action={{
+        text: 'Undo',
+        handler: () => {
+          console.log('Clicked action');
+        },
+      }}
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+    <ToastBanner
+      message="Test Message"
+      variant="danger"
+      action={{
+        text: 'Undo',
+        handler: () => {
+          console.log('Clicked action');
+        },
+      }}
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+    <ToastBanner
+      message="Test Message"
+      variant="warning"
+      action={{
+        text: 'Undo',
+        handler: () => {
+          console.log('Clicked action');
+        },
+      }}
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
+  </div>
+
+  <!-- Toast Container -->
+  <h1 class="text-2xl">Toast Container</h1>
+
+  <div class="flex gap-4">
+    <ToastContainer />
+    <div>
+      <Button
+        on:click={() => {
+          toast({ message: 'Success', variant: 'success' });
+        }}
+      >
+        Click to show "Success" button
+      </Button>
+    </div>
+    <div>
+      <Button
+        on:click={() => {
+          toast({ message: 'Information', variant: 'info' });
+        }}
+      >
+        Click to show "Info" button
+      </Button>
+    </div>
+    <div>
+      <Button
+        on:click={() => {
+          toast({ message: 'Dangerous', variant: 'danger' });
+        }}
+      >
+        Click to show "Danger" button
+      </Button>
+    </div>
+    <div>
+      <Button
+        on:click={() => {
+          toast({ message: 'Warning', variant: 'warning' });
+        }}
+      >
+        Click to show "Warning" button
+      </Button>
+    </div>
   </div>
 
   <!-- Toggle Buttons -->

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1708,6 +1708,20 @@ const onHoverDelayMsInput = (event: Event) => {
       }}
       cx="max-w-[240px]"
     />
+    <ToastBanner
+      message="Test Message"
+      variant={ToastVariant.Neutral}
+      action={{
+        text: 'Undo',
+        handler: () => {
+          console.log('Clicked action');
+        },
+      }}
+      dismiss={() => {
+        console.log('Clicked close button');
+      }}
+      cx="max-w-[240px]"
+    />
   </div>
 
   <!-- Toast Container -->

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1616,7 +1616,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1624,7 +1623,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1632,7 +1630,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1640,7 +1637,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1648,7 +1644,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
   </div>
   <div class="flex gap-4">
@@ -1664,7 +1659,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1678,7 +1672,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1692,7 +1685,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1706,7 +1698,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
     <ToastBanner
       message="Test Message"
@@ -1720,7 +1711,6 @@ const onHoverDelayMsInput = (event: Event) => {
       dismiss={() => {
         console.log('Clicked close button');
       }}
-      cx="max-w-[240px]"
     />
   </div>
 

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -33,6 +33,7 @@ import {
   TableRow,
   ToastBanner,
   ToastContainer,
+  ToastVariantType,
   ToggleButtons,
   Select,
   SearchableSelect,
@@ -1611,7 +1612,7 @@ const onHoverDelayMsInput = (event: Event) => {
   <div class="flex gap-4">
     <ToastBanner
       message="Test Message"
-      variant="success"
+      variant=ToastVariantType.Success
       dismiss={() => {
         console.log('Clicked close button');
       }}

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1612,7 +1612,7 @@ const onHoverDelayMsInput = (event: Event) => {
   <div class="flex gap-4">
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Success }
+      variant={ToastVariant.Success}
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1620,7 +1620,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Info }
+      variant={ToastVariant.Info}
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1628,7 +1628,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Danger }
+      variant={ToastVariant.Danger}
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1636,7 +1636,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Warning }
+      variant={ToastVariant.Warning}
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1644,7 +1644,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Neutral }
+      variant={ToastVariant.Neutral}
       dismiss={() => {
         console.log('Clicked close button');
       }}
@@ -1654,7 +1654,7 @@ const onHoverDelayMsInput = (event: Event) => {
   <div class="flex gap-4">
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Success }
+      variant={ToastVariant.Success}
       action={{
         text: 'Undo',
         handler: () => {
@@ -1668,7 +1668,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Info }
+      variant={ToastVariant.Info}
       action={{
         text: 'Undo',
         handler: () => {
@@ -1682,7 +1682,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Danger }
+      variant={ToastVariant.Danger}
       action={{
         text: 'Undo',
         handler: () => {
@@ -1696,7 +1696,7 @@ const onHoverDelayMsInput = (event: Event) => {
     />
     <ToastBanner
       message="Test Message"
-      variant={ ToastVariant.Warning }
+      variant={ToastVariant.Warning}
       action={{
         text: 'Undo',
         handler: () => {

--- a/packages/storybook/src/stories/toast-banner.mdx
+++ b/packages/storybook/src/stories/toast-banner.mdx
@@ -5,7 +5,7 @@ import * as ToastBannerStories from './toast-banner.stories.svelte';
 
 # ToastBanner
 
-Toast Banner message of type success.
+You can specify a toast banner message of 5 types: success, info, warn, danger, and neutral.
 
 ```ts
 import { ToastBanner } from '@viamrobotics/prime-core';
@@ -14,6 +14,24 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 <Canvas>
   <Story of={ToastBannerStories.Success} />
 </Canvas>
+
+<Canvas>
+  <Story of={ToastBannerStories.Info} />
+</Canvas>
+
+<Canvas>
+  <Story of={ToastBannerStories.Danger} />
+</Canvas>
+
+<Canvas>
+  <Story of={ToastBannerStories.Warning} />
+</Canvas>
+
+<Canvas>
+  <Story of={ToastBannerStories.Neutral} />
+</Canvas>
+
+An option action can also be specified in the Toast.
 
 <Canvas>
   <Story of={ToastBannerStories.SuccessWithEmphasizedAction} />

--- a/packages/storybook/src/stories/toast-banner.stories.svelte
+++ b/packages/storybook/src/stories/toast-banner.stories.svelte
@@ -7,17 +7,58 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 
 <Story name="Success">
   <ToastBanner
+    variant="success"
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
     }}
-    cx="max-w-[240px]"
+  />
+</Story>
+
+<Story name="Info">
+  <ToastBanner
+    variant="info"
+    message="Saved configuration"
+    dismiss={() => {
+      console.log('Clicked close button');
+    }}
+  />
+</Story>
+
+<Story name="Danger">
+  <ToastBanner
+    variant="danger"
+    message="Saved configuration"
+    dismiss={() => {
+      console.log('Clicked close button');
+    }}
+  />
+</Story>
+
+<Story name="Warning">
+  <ToastBanner
+    variant="warning"
+    message="Saved configuration"
+    dismiss={() => {
+      console.log('Clicked close button');
+    }}
+  />
+</Story>
+
+<Story name="Neutral">
+  <ToastBanner
+    variant="neutral"
+    message="Saved configuration"
+    dismiss={() => {
+      console.log('Clicked close button');
+    }}
   />
 </Story>
 
 <Story name="SuccessWithEmphasizedAction">
   <ToastBanner
     message={`Deleted "my-arm"`}
+    variant="success"
     dismiss={() => {
       console.log('Clicked close button');
     }}

--- a/packages/storybook/src/stories/toast-banner.stories.svelte
+++ b/packages/storybook/src/stories/toast-banner.stories.svelte
@@ -1,13 +1,13 @@
 <script lang="ts">
 import { Meta, Story } from '@storybook/addon-svelte-csf';
-import { ToastBanner } from '@viamrobotics/prime-core';
+import { ToastBanner, ToastVariant } from '@viamrobotics/prime-core';
 </script>
 
 <Meta title="Elements/ToastBanner" />
 
 <Story name="Success">
   <ToastBanner
-    variant="success"
+    variant={ ToastVariant.Success }
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -17,7 +17,7 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 
 <Story name="Info">
   <ToastBanner
-    variant="info"
+    variant={ ToastVariant.Info }
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -27,7 +27,7 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 
 <Story name="Danger">
   <ToastBanner
-    variant="danger"
+    variant={ ToastVariant.Danger }
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -37,7 +37,7 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 
 <Story name="Warning">
   <ToastBanner
-    variant="warning"
+    variant={ ToastVariant.Warning }
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -47,7 +47,7 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 
 <Story name="Neutral">
   <ToastBanner
-    variant="neutral"
+    variant={ ToastVariant.Neutral }
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -58,7 +58,7 @@ import { ToastBanner } from '@viamrobotics/prime-core';
 <Story name="SuccessWithEmphasizedAction">
   <ToastBanner
     message={`Deleted "my-arm"`}
-    variant="success"
+    variant={ ToastVariant.Success }
     dismiss={() => {
       console.log('Clicked close button');
     }}

--- a/packages/storybook/src/stories/toast-banner.stories.svelte
+++ b/packages/storybook/src/stories/toast-banner.stories.svelte
@@ -7,7 +7,7 @@ import { ToastBanner, ToastVariant } from '@viamrobotics/prime-core';
 
 <Story name="Success">
   <ToastBanner
-    variant={ ToastVariant.Success }
+    variant={ToastVariant.Success}
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -17,7 +17,7 @@ import { ToastBanner, ToastVariant } from '@viamrobotics/prime-core';
 
 <Story name="Info">
   <ToastBanner
-    variant={ ToastVariant.Info }
+    variant={ToastVariant.Info}
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -27,7 +27,7 @@ import { ToastBanner, ToastVariant } from '@viamrobotics/prime-core';
 
 <Story name="Danger">
   <ToastBanner
-    variant={ ToastVariant.Danger }
+    variant={ToastVariant.Danger}
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -37,7 +37,7 @@ import { ToastBanner, ToastVariant } from '@viamrobotics/prime-core';
 
 <Story name="Warning">
   <ToastBanner
-    variant={ ToastVariant.Warning }
+    variant={ToastVariant.Warning}
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -47,7 +47,7 @@ import { ToastBanner, ToastVariant } from '@viamrobotics/prime-core';
 
 <Story name="Neutral">
   <ToastBanner
-    variant={ ToastVariant.Neutral }
+    variant={ToastVariant.Neutral}
     message="Saved configuration"
     dismiss={() => {
       console.log('Clicked close button');
@@ -58,7 +58,7 @@ import { ToastBanner, ToastVariant } from '@viamrobotics/prime-core';
 <Story name="SuccessWithEmphasizedAction">
   <ToastBanner
     message={`Deleted "my-arm"`}
-    variant={ ToastVariant.Success }
+    variant={ToastVariant.Success}
     dismiss={() => {
       console.log('Clicked close button');
     }}

--- a/packages/storybook/src/stories/use-toast.mdx
+++ b/packages/storybook/src/stories/use-toast.mdx
@@ -16,7 +16,7 @@ The root layout component is probably the best place to set up the context.
 ```svelte
 <!-- +layout.svelte -->
 <script lang="ts">
-import { ToastContainer } from '@viamrobotics/prime-core';
+import { ToastContainer, ToastVariant } from '@viamrobotics/prime-core';
 
 import PageRoot from '$lib/layout/page-root.svelte';
 import PageContent from '$lib/layout/page-content.svelte';
@@ -40,7 +40,7 @@ import { provideToast } from '@viamrobotics/prime-core';
 const doSomethingCrazy = () => {
   const toast = provideToast();
 
-  toast({ message: 'Hello, Brooklyn!', variant: 'success' });
+  toast({ message: 'Hello, Brooklyn!', variant: ToastVariant.Success });
 };
 ```
 

--- a/packages/storybook/src/stories/use-toast.mdx
+++ b/packages/storybook/src/stories/use-toast.mdx
@@ -32,7 +32,7 @@ import PageContent from '$lib/layout/page-content.svelte';
 
 ## Usage
 
-To display a toast, use the `useToast` function:
+To display a toast, first provide access to the Toast context using `provideToast`. Then, you can use the `useToast` function:
 
 ```ts
 import { provideToast } from '@viamrobotics/prime-core';
@@ -40,11 +40,13 @@ import { provideToast } from '@viamrobotics/prime-core';
 const doSomethingCrazy = () => {
   const toast = provideToast();
 
-  toast({ message: 'Hello, Brooklyn!', variant: ToastVariant.Success });
+  toast({ message: 'Hello, Brooklyn!', variant: 'success' });
 };
 ```
 
-Right now only different variants of a success toast is supported.
+If the variant is not specified, the default is "success".
+
+An action can also be specified in the params to `useToast`.
 
 ```ts
 import { provideToast } from '@viamrobotics/prime-core';
@@ -54,13 +56,8 @@ const doSomethingCrazy = () => {
   const exampleHanderFunction = () => void;
 
   toast({ message: 'Plain slice please!' });
-  toast({ message: 'Plain slice please!', action: { text: 'action', handler: exampleHandlerFunction });
-
+  toast({ message: 'Plain slice please!', action: { text: 'action', handler: exampleHandlerFunction } });
 };
-```
-
-```ts
-import { provideToast } from '@viamrobotics/prime-core';
 ```
 
 <Canvas>

--- a/packages/storybook/src/stories/use-toast.stories.svelte
+++ b/packages/storybook/src/stories/use-toast.stories.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
 import { Meta, Story } from '@storybook/addon-svelte-csf';
-import { Button, ToastContainer, ToastVariant, provideToast } from '@viamrobotics/prime-core';
+import {
+  Button,
+  ToastContainer,
+  ToastVariant,
+  provideToast,
+} from '@viamrobotics/prime-core';
 
 const toast = provideToast();
 </script>

--- a/packages/storybook/src/stories/use-toast.stories.svelte
+++ b/packages/storybook/src/stories/use-toast.stories.svelte
@@ -16,6 +16,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Success message',
+            variant: 'success',
           })}
       >
         Success
@@ -23,7 +24,44 @@ const toast = provideToast();
       <Button
         on:click={() =>
           toast({
+            message: 'Info message',
+            variant: 'info',
+          })}
+      >
+        Info
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
+            message: 'Danger message',
+            variant: 'danger',
+          })}
+      >
+        Danger
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
+            message: 'Warning message',
+            variant: 'warning',
+          })}
+      >
+        Warning
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
+            message: 'Neutral message',
+            variant: 'neutral',
+          })}
+      >
+        Neutral
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
             message: 'Success message',
+            variant: 'success',
             action: {
               text: 'action',
               handler: () => {
@@ -33,6 +71,66 @@ const toast = provideToast();
           })}
       >
         Success with action
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
+            message: 'Info message',
+            variant: 'info',
+            action: {
+              text: 'action',
+              handler: () => {
+                console.log('Clicked action');
+              },
+            },
+          })}
+      >
+        Info with action
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
+            message: 'Danger message',
+            variant: 'danger',
+            action: {
+              text: 'action',
+              handler: () => {
+                console.log('Clicked action');
+              },
+            },
+          })}
+      >
+        Danger with action
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
+            message: 'Warning message',
+            variant: 'warning',
+            action: {
+              text: 'action',
+              handler: () => {
+                console.log('Clicked action');
+              },
+            },
+          })}
+      >
+        Warning with action
+      </Button>
+      <Button
+        on:click={() =>
+          toast({
+            message: 'Neutral message',
+            variant: 'neutral',
+            action: {
+              text: 'action',
+              handler: () => {
+                console.log('Clicked action');
+              },
+            },
+          })}
+      >
+        Neutral with action
       </Button>
     </div>
   </div>

--- a/packages/storybook/src/stories/use-toast.stories.svelte
+++ b/packages/storybook/src/stories/use-toast.stories.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 import { Meta, Story } from '@storybook/addon-svelte-csf';
-import { Button, ToastContainer, provideToast } from '@viamrobotics/prime-core';
+import { Button, ToastContainer, ToastVariant, provideToast } from '@viamrobotics/prime-core';
 
 const toast = provideToast();
 </script>
@@ -16,7 +16,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Success message',
-            variant: 'success',
+            variant: ToastVariant.Success,
           })}
       >
         Success
@@ -25,7 +25,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Info message',
-            variant: 'info',
+            variant: ToastVariant.Info,
           })}
       >
         Info
@@ -34,7 +34,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Danger message',
-            variant: 'danger',
+            variant: ToastVariant.Danger,
           })}
       >
         Danger
@@ -43,7 +43,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Warning message',
-            variant: 'warning',
+            variant: ToastVariant.Warning,
           })}
       >
         Warning
@@ -52,7 +52,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Neutral message',
-            variant: 'neutral',
+            variant: ToastVariant.Neutral,
           })}
       >
         Neutral
@@ -61,7 +61,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Success message',
-            variant: 'success',
+            variant: ToastVariant.Success,
             action: {
               text: 'action',
               handler: () => {
@@ -76,7 +76,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Info message',
-            variant: 'info',
+            variant: ToastVariant.Info,
             action: {
               text: 'action',
               handler: () => {
@@ -91,7 +91,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Danger message',
-            variant: 'danger',
+            variant: ToastVariant.Danger,
             action: {
               text: 'action',
               handler: () => {
@@ -106,7 +106,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Warning message',
-            variant: 'warning',
+            variant: ToastVariant.Warning,
             action: {
               text: 'action',
               handler: () => {
@@ -121,7 +121,7 @@ const toast = provideToast();
         on:click={() =>
           toast({
             message: 'Neutral message',
-            variant: 'neutral',
+            variant: ToastVariant.Neutral,
             action: {
               text: 'action',
               handler: () => {


### PR DESCRIPTION
## Description
Currently there is only a success toast variant. This PR creates 4 more toast variants: warn, danger, info, and neutral in accordance with [Figma](https://www.figma.com/design/ERHSYDGTXiEQOVGY8ORg6I/PRIME?node-id=2650-4380&t=JEKiEAXH14oyuHHr-0). It also makes edits to the existing toast design to be in line with Figma as well. 

**Note:** One test had to be edited to use `getByText` instead of `getByRole` as the aria-label for the action button of the toast banner was removed.