### PR TITLE
[APP-4882] - get toast message to truncate when overflowing

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.126",
+  "version": "0.0.127",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -31,7 +31,7 @@ export { extraClasses as cx };
 
 <div
   class={cx(
-    'relative flex h-10 w-max max-w-[480px] shrink-0 items-center border border-medium bg-medium pl-3 pr-1 text-sm text-default shadow-sm',
+    'relative flex h-10 w-max max-w-[480px] items-center border border-medium bg-medium pl-3 pr-1 text-sm text-default shadow-sm',
     extraClasses
   )}
 >
@@ -39,7 +39,7 @@ export { extraClasses as cx };
     <Icon
       size="lg"
       name={displayDetails.icon}
-      cx={displayDetails.iconClasses}
+      cx={['shrink-0', displayDetails.iconClasses]}
       role="img"
       aria-hidden={false}
       aria-label={displayDetails.label}

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -35,7 +35,7 @@ export { extraClasses as cx };
     extraClasses
   )}
 >
-  <div class="mr-4 flex gap-2">
+  <div class="mr-4 flex gap-4 truncate">
     <Icon
       size="lg"
       name={displayDetails.icon}

--- a/packages/core/src/lib/toast/toast-banner.svelte
+++ b/packages/core/src/lib/toast/toast-banner.svelte
@@ -31,7 +31,7 @@ export { extraClasses as cx };
 
 <div
   class={cx(
-    'relative flex h-10 w-max max-w-[480px] items-center border border-medium bg-medium pl-3 pr-1 text-sm text-default shadow-sm',
+    'relative flex h-10 w-max max-w-[480px] shrink-0 items-center border border-medium bg-medium pl-3 pr-1 text-sm text-default shadow-sm',
     extraClasses
   )}
 >

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -14,22 +14,22 @@ export const DisplayDetailsByVariant = {
   },
   [ToastVariant.Warning]: {
     icon: 'alert',
-    iconClasses: 'text-warning-bright shrink-0',
+    iconClasses: 'text-warning-bright',
     label: 'warning',
   },
   [ToastVariant.Danger]: {
     icon: 'alert-circle',
-    iconClasses: 'text-danger-dark shrink-0',
+    iconClasses: 'text-danger-dark',
     label: 'danger',
   },
   [ToastVariant.Success]: {
     icon: 'check-circle',
-    iconClasses: 'text-success-dark shrink-0',
+    iconClasses: 'text-success-dark',
     label: 'success',
   },
   [ToastVariant.Neutral]: {
     icon: 'domain',
-    iconClasses: 'text-gray-7 shrink-0',
+    iconClasses: 'text-gray-7',
     label: 'neutral',
   },
 } as const;

--- a/packages/core/src/lib/toast/variants.ts
+++ b/packages/core/src/lib/toast/variants.ts
@@ -14,22 +14,22 @@ export const DisplayDetailsByVariant = {
   },
   [ToastVariant.Warning]: {
     icon: 'alert',
-    iconClasses: 'text-warning-bright',
+    iconClasses: 'text-warning-bright shrink-0',
     label: 'warning',
   },
   [ToastVariant.Danger]: {
     icon: 'alert-circle',
-    iconClasses: 'text-danger-dark',
+    iconClasses: 'text-danger-dark shrink-0',
     label: 'danger',
   },
   [ToastVariant.Success]: {
     icon: 'check-circle',
-    iconClasses: 'text-success-dark',
+    iconClasses: 'text-success-dark shrink-0',
     label: 'success',
   },
   [ToastVariant.Neutral]: {
     icon: 'domain',
-    iconClasses: 'text-gray-7',
+    iconClasses: 'text-gray-7 shrink-0',
     label: 'neutral',
   },
 } as const;

--- a/packages/storybook/README.md
+++ b/packages/storybook/README.md
@@ -13,6 +13,8 @@ First, build the other packages for use in storybook:
 pnpm -r build
 ```
 
+**NOTE:** Storybook does not have the hot reloading feature. You must rebuild the package using the above command every time there is a change.
+
 Then run the storybook:
 
 ```


### PR DESCRIPTION
## Description
This PR adds truncation to the text of a toast.

![image](https://github.com/viamrobotics/prime/assets/64320145/4de1e550-c5f4-4017-a4e8-afed9774a788)

Note: this change is possible as all of the toast verbiage has the format "{action} {name}", like "created test" or "renamed test". So there will be no issues with the action being cut off at the end.