### PR TITLE
APP-6034: Fix slam path linewidth

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-blocks",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/viamrobotics/prime.git",

--- a/packages/blocks/src/lib/slam-map-2d/motion-path.svelte
+++ b/packages/blocks/src/lib/slam-map-2d/motion-path.svelte
@@ -51,7 +51,7 @@ $: {
   <T.Line2 renderOrder={renderOrder.motionPath}>
     <T.LineMaterial
       color="#FF0047"
-      linewidth={0.005}
+      linewidth={1}
     />
     <T is={geometry} />
   </T.Line2>


### PR DESCRIPTION
Lines were missing, turns out they had a minuscule width! Now rendering properly:

<img width="1064" alt="Screenshot 2024-09-03 at 4 04 33 PM" src="https://github.com/user-attachments/assets/dcc41c20-8321-461b-a6f0-9760ff356ea0">
