### PR TITLE
App 6327 searchable select font size

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.154",
+  "version": "0.0.155",
   "repository": {
     "type": "git",
     "url": "https://github.com/viamrobotics/prime.git",

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -404,8 +404,13 @@ const handleKeydown = createHandleKey({
                 name={option.icon}
               />
             {/if}
-            <div class="flex flex-col [overflow-wrap:anywhere]">
-              <p class="text-sm">
+            <div class="flex flex-col">
+              <p
+                class={cx(
+                  'text-wrap',
+                  option.description ? 'text-sm' : 'text-xs'
+                )}
+              >
                 {#if highlight !== undefined}
                   {@const [prefix, match, suffix] = highlight}
                   {prefix}<span class="bg-yellow-100">{match}</span>{suffix}

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -404,13 +404,8 @@ const handleKeydown = createHandleKey({
                 name={option.icon}
               />
             {/if}
-            <div class="flex flex-col">
-              <p
-                class={cx(
-                  'text-wrap',
-                  option.description ? 'text-sm' : 'text-xs'
-                )}
-              >
+            <div class="flex flex-col text-xs [overflow-wrap:anywhere]">
+              <p>
                 {#if highlight !== undefined}
                   {@const [prefix, match, suffix] = highlight}
                   {prefix}<span class="bg-yellow-100">{match}</span>{suffix}
@@ -423,7 +418,7 @@ const handleKeydown = createHandleKey({
               {#if option.description}
                 <p
                   id={descriptionID}
-                  class="text-xs text-subtle-2"
+                  class=" text-subtle-2"
                 >
                   {option.description}
                 </p>


### PR DESCRIPTION
Fix default font size for searchable select.

<img width="382" alt="image" src="https://github.com/user-attachments/assets/9f03e52a-9065-475f-9828-0f53b9d707b0">