### PR TITLE
Break words in SearchableSelect value & description

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.151",
+  "version": "0.0.152",
   "repository": {
     "type": "git",
     "url": "https://github.com/viamrobotics/prime.git",

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -404,8 +404,11 @@ const handleKeydown = createHandleKey({
                 name={option.icon}
               />
             {/if}
-            <div class="flex flex-col">
-              <p class="text-wrap text-sm">
+            <div
+              class="flex flex-col"
+              style="overflow-wrap: anywhere;"
+            >
+              <p class="text-sm">
                 {#if highlight !== undefined}
                   {@const [prefix, match, suffix] = highlight}
                   {prefix}<span class="bg-yellow-100">{match}</span>{suffix}
@@ -418,7 +421,7 @@ const handleKeydown = createHandleKey({
               {#if option.description}
                 <p
                   id={descriptionID}
-                  class="text-wrap text-xs text-subtle-2"
+                  class="text-xs text-subtle-2"
                 >
                   {option.description}
                 </p>

--- a/packages/core/src/lib/select/searchable-select.svelte
+++ b/packages/core/src/lib/select/searchable-select.svelte
@@ -404,10 +404,7 @@ const handleKeydown = createHandleKey({
                 name={option.icon}
               />
             {/if}
-            <div
-              class="flex flex-col"
-              style="overflow-wrap: anywhere;"
-            >
+            <div class="flex flex-col [overflow-wrap:anywhere]">
               <p class="text-sm">
                 {#if highlight !== undefined}
                   {@const [prefix, match, suffix] = highlight}

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -1091,6 +1091,11 @@ const onHoverDelayMsInput = (event: Event) => {
             'Option 2',
             { value: 'C.) Option', description: 'second' },
             'A really long forth option just in case you need it',
+            {
+              value: 'Option with a long description',
+              description:
+                'usb-Generic_Laptop_Camera_200901010001-video-index0',
+            },
           ]}
           placeholder="Select an option"
           onChange={(value) => {


### PR DESCRIPTION
I know we are deprecating `SearchableSelect`. However, the `video-path` dropdown for the webcam component builder has caused me enough emotional pain to just come fix this. Thoughts?



Before:
![before](https://github.com/user-attachments/assets/89fe0f4d-51f4-4fa1-bd03-2ffc78cb43a0)

After:
![20240919_01h54m16s_grim](https://github.com/user-attachments/assets/97f797a9-4b5d-4a0d-be20-38102a786684)

