### PR TITLE
bug fix - clickOutside api

### DIFF
--- a/packages/core/src/lib/__tests__/click-outside.spec.ts
+++ b/packages/core/src/lib/__tests__/click-outside.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/svelte';
+import { fireEvent, render, screen } from '@testing-library/svelte';
 import userEvent from '@testing-library/user-event';
 
 import Subject from './click-outside.spec.svelte';
@@ -38,5 +38,20 @@ describe('use:clickOutside', () => {
     await user.click(insideButton);
 
     expect(onClickOutside).not.toHaveBeenCalled();
+  });
+
+  it('should not trigger for long clicks', async () => {
+    render(Subject, { onClickOutside });
+
+    const outsideButton = screen.getByTestId('outside');
+
+    await fireEvent.mouseDown(outsideButton);
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+
+    await fireEvent.mouseUp(outsideButton);
+
+    expect(onClickOutside).not.toHaveBeenCalledWith(outsideButton);
   });
 });


### PR DESCRIPTION
[Moving mouse outside of component/service selector while changing name, closes the menu](https://viam.atlassian.net/jira/software/c/projects/APP/boards/51?assignee=61ccb917e67ea2006b7ffcd1&selectedIssue=APP-6535)