### PR TITLE
Fix: allow pill anchor target to remain unspecified

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.165",
+  "version": "0.0.166",
   "repository": {
     "type": "git",
     "url": "https://github.com/viamrobotics/prime.git",

--- a/packages/core/src/lib/__tests__/pill.spec.ts
+++ b/packages/core/src/lib/__tests__/pill.spec.ts
@@ -81,10 +81,20 @@ describe('Pill', () => {
 
   it('Renders with the passed href', () => {
     render(Pill, { value: 'link', href: 'https://www.viam.com' });
-    expect(screen.getByRole('link', { name: 'link' })).toHaveAttribute(
-      'href',
-      'https://www.viam.com'
-    );
+    const anchor = screen.getByRole('link', { name: 'link' });
+
+    expect(anchor).toHaveAttribute('href', 'https://www.viam.com');
+    expect(anchor).not.toHaveAttribute('target');
+  });
+
+  it('May set anchor target', () => {
+    render(Pill, {
+      props: { value: 'link', href: 'https://www.viam.com', target: '_blank' },
+    });
+    const anchor = screen.getByRole('link', { name: 'link' });
+
+    expect(anchor).toHaveAttribute('href', 'https://www.viam.com');
+    expect(anchor).toHaveAttribute('target', '_blank');
   });
 
   it('Renders icon tooltip when hovered', async () => {

--- a/packages/core/src/lib/pill.svelte
+++ b/packages/core/src/lib/pill.svelte
@@ -28,7 +28,8 @@ export let value = '';
 export let href = '';
 
 /** Optional target for linked URL. */
-export let target: '_self' | '_blank' | '_parent' | '_top' = '_blank';
+export let target: '_self' | '_blank' | '_parent' | '_top' | undefined =
+  undefined;
 
 /** Whether or not the pill has the aria-readonly attribute. If readonly, there is not a button to remove the pill. */
 export let readonly = false;


### PR DESCRIPTION
## Overview

- The `<Pill>` component can take an `href`
- If an `href` is provided, the `target` attribute of the anchor defaults to `_blank`
- If a consumer does not want to open the link in a new tab, they add `target="_self"`
- `_self` causes SvelteKit to trigger a full page reload instead of client-side routing
    - Intentional, but undocumented behavior from SK, according to an old GH thread in Sapper
    - See how clicking on parts and machines from the "All Machines Dashboard" reloads the page instead of preloading and rendering in

This PR removes the default `_blank` and sets it to `undefined`, which will be a more reliable default. A couple call-sites will need to be updated, but otherwise most existing call-sites that rely on the `_blank` default already specify it explicitly.

## Review requests

Check that above reasoning makes sense