### PR TITLE
APP-7173: Add Prism code highlighting action

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.169",
+  "version": "0.0.170",
   "repository": {
     "type": "git",
     "url": "https://github.com/viamrobotics/prime.git",

--- a/packages/core/src/lib/__tests__/code-snippet.spec.ts
+++ b/packages/core/src/lib/__tests__/code-snippet.spec.ts
@@ -56,16 +56,6 @@ describe('CodeSnippet', () => {
     expect(button).toBeNull();
   });
 
-  it('Renders with the passed dependencies', () => {
-    render(CodeSnippet, { ...common, dependencies: ['dep1', 'dep2'] });
-
-    const code = screen
-      .getByRole('figure')
-      .querySelector('pre > code.language-json');
-
-    expect(code).toHaveAttribute('data-dependencies', 'dep1,dep2');
-  });
-
   it('Renders with a figcaption when the default slot is provided', () => {
     render(CaptionedCodeSnippet);
 

--- a/packages/core/src/lib/code-snippet.svelte
+++ b/packages/core/src/lib/code-snippet.svelte
@@ -17,12 +17,6 @@ https://prismjs.com
   context="module"
   lang="ts"
 >
-import Prism from 'prismjs';
-import PrismPackage from 'prismjs/package.json';
-import 'prism-themes/themes/prism-vs.min.css';
-
-const PRISM_VERSION = PrismPackage.version;
-
 type CodeSnippetCopyState = 'copy' | 'copied' | 'failed';
 const COPY_STATES: Record<
   CodeSnippetCopyState,
@@ -35,11 +29,11 @@ const COPY_STATES: Record<
 </script>
 
 <script lang="ts">
-import { createEventDispatcher, onMount } from 'svelte';
+import { createEventDispatcher } from 'svelte';
 import cx from 'classnames';
 
 import { IconButton, type IconName, useTimeout } from '$lib';
-import { escape } from 'lodash-es';
+import { highlightCode } from './highlight-code/highlight-code';
 
 /**
  * The language to use for syntax highlighting. Must be a language supported by
@@ -65,22 +59,11 @@ export let showCopyButton = true;
  */
 export let dependencies: string[] = [];
 
-/**
- * We use the prism autoloader to handle loading in language grammar files. The
- * default path for the grammar files is a CDN link so we don't have to include
- * grammar files in our bundle. If you prefer to point to your own grammars and
- * bypass the CDN, define the path to those files.
- *
- * See: https://prismjs.com/plugins/autoloader/
- */
-export let grammarsPath = `https://cdnjs.cloudflare.com/ajax/libs/prism/${PRISM_VERSION}/components/`;
-
 /** Additional CSS classes to pass to the aside. */
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
 
 const { set: setCopyTimeout } = useTimeout();
-let element: HTMLElement | undefined;
 
 $: copyState = 'copy' as CodeSnippetCopyState;
 
@@ -110,44 +93,6 @@ const copyToClipboard = async () => {
     copyState = 'copy';
   }, 2000);
 };
-
-const highlight = () => {
-  if (element) {
-    /**
-     * We need to reset the inner HTML of the element to the raw value of
-     * `code` so it can rescanned for highlighting from the raw.
-     */
-    element.innerHTML = escape(code);
-    Prism.highlightElement(element);
-  }
-};
-
-$: if (code) {
-  highlight();
-}
-
-onMount(async () => {
-  try {
-    /**
-     * After the HTML is loaded in the DOM, we can use the autoloader to manage
-     * scanning for languages and including the components properly
-     */
-    await import(
-      // @ts-expect-error no type declaration for this JS file
-      'prismjs/plugins/autoloader/prism-autoloader'
-    );
-
-    // Make sure the autoloader knows where to find our languages
-    (Prism.plugins.autoloader as { languages_path: string }).languages_path =
-      grammarsPath;
-
-    // Do the initial highlighting
-    highlight();
-  } catch (error) {
-    /* eslint-disable-next-line no-console */
-    console.error('Error initializing prismjs', error);
-  }
-});
 </script>
 
 <figure class={cx('flex flex-col gap-2', extraClasses)}>
@@ -157,8 +102,9 @@ onMount(async () => {
 
   <div class="flex gap-x-4 bg-light p-4">
     <!-- The formatting here is intentional to preserve the formatting of `code` -->
-    <pre class="flex-1 overflow-x-auto language-{language}"><code
-        bind:this={element}
+    <pre
+      class="code-snippet flex-1 overflow-x-auto"
+      use:highlightCode><code
         class="language-{language}"
         data-dependencies={dependencies.join(',')}>{code}</code
       ></pre>
@@ -177,18 +123,18 @@ onMount(async () => {
 
 <style>
 /* Theme overrides */
-figure pre[class*='language-'],
-figure pre[class*='language-'] > code[class*='language-'] {
+pre.code-snippet,
+pre.code-snippet > code[class*='language-'] {
   margin: 0;
   border: none;
   background: inherit;
 }
 
-figure pre[class*='language-'] {
+pre.code-snippet {
   padding: 0;
 }
 
-figure pre[class*='language-'] > code[class*='language-'] {
+pre.code-snippet > code[class*='language-'] {
   font-family: 'Roboto Mono Variable', 'Roboto Mono', ui-monospace, monospace;
   font-size: 1em;
 }

--- a/packages/core/src/lib/code-snippet.svelte
+++ b/packages/core/src/lib/code-snippet.svelte
@@ -96,10 +96,7 @@ const copyToClipboard = async () => {
     <!-- The formatting here is intentional to preserve the formatting of `code` -->
     <pre
       class="flex-1 overflow-x-auto"
-      use:highlightCode><code
-        class="language-{language}"
-    >{code}</code
-    ></pre>
+      use:highlightCode><code class="language-{language}">{code}</code></pre>
 
     {#if showCopyButton}
       <IconButton

--- a/packages/core/src/lib/code-snippet.svelte
+++ b/packages/core/src/lib/code-snippet.svelte
@@ -33,7 +33,7 @@ import { createEventDispatcher } from 'svelte';
 import cx from 'classnames';
 
 import { IconButton, type IconName, useTimeout } from '$lib';
-import { highlightCode } from './highlight-code/highlight-code';
+import { highlightCode } from '$lib/highlight-code';
 
 /**
  * The language to use for syntax highlighting. Must be a language supported by
@@ -103,7 +103,7 @@ const copyToClipboard = async () => {
   <div class="flex gap-x-4 bg-light p-4">
     <!-- The formatting here is intentional to preserve the formatting of `code` -->
     <pre
-      class="code-snippet flex-1 overflow-x-auto"
+      class="flex-1 overflow-x-auto"
       use:highlightCode><code
         class="language-{language}"
         data-dependencies={dependencies.join(',')}>{code}</code
@@ -120,22 +120,3 @@ const copyToClipboard = async () => {
     {/if}
   </div>
 </figure>
-
-<style>
-/* Theme overrides */
-pre.code-snippet,
-pre.code-snippet > code[class*='language-'] {
-  margin: 0;
-  border: none;
-  background: inherit;
-}
-
-pre.code-snippet {
-  padding: 0;
-}
-
-pre.code-snippet > code[class*='language-'] {
-  font-family: 'Roboto Mono Variable', 'Roboto Mono', ui-monospace, monospace;
-  font-size: 1em;
-}
-</style>

--- a/packages/core/src/lib/code-snippet.svelte
+++ b/packages/core/src/lib/code-snippet.svelte
@@ -51,14 +51,6 @@ export let code: string;
  */
 export let showCopyButton = true;
 
-/**
- * Some prism languages have dependencies. For example, C++ requires C. If the
- * passed `language` has dependencies, they must be included here to be loaded.
- *
- * See: https://prismjs.com/plugins/autoloader/
- */
-export let dependencies: string[] = [];
-
 /** Additional CSS classes to pass to the aside. */
 let extraClasses: cx.Argument = '';
 export { extraClasses as cx };
@@ -106,8 +98,8 @@ const copyToClipboard = async () => {
       class="flex-1 overflow-x-auto"
       use:highlightCode><code
         class="language-{language}"
-        data-dependencies={dependencies.join(',')}>{code}</code
-      ></pre>
+    >{code}</code
+    ></pre>
 
     {#if showCopyButton}
       <IconButton

--- a/packages/core/src/lib/highlight-code/highlight-code.ts
+++ b/packages/core/src/lib/highlight-code/highlight-code.ts
@@ -2,7 +2,10 @@ import type { Action } from 'svelte/action';
 import { getPrismModule } from './prism';
 
 /**
- * Highlight code in any child `<code>` blocks.
+ * Highlight code in any child `<pre><code /></pre>` blocks.
+ * Elements should be styled according to Prism's expected HTML structure
+ *
+ * @param node - The node to highlight.
  */
 export const highlightCode: Action<HTMLElement | undefined> = (
   node: HTMLElement | undefined
@@ -12,7 +15,7 @@ export const highlightCode: Action<HTMLElement | undefined> = (
   }
 };
 
-const highlightContainerElement = async (element: Element) => {
-  const prism = await getPrismModule();
+const highlightContainerElement = (element: Element) => {
+  const prism = getPrismModule();
   prism.highlightAllUnder(element);
 };

--- a/packages/core/src/lib/highlight-code/highlight-code.ts
+++ b/packages/core/src/lib/highlight-code/highlight-code.ts
@@ -1,0 +1,18 @@
+import type { Action } from 'svelte/action';
+import { getPrismModule } from './prism';
+
+/**
+ * Highlight code in any child `<code>` blocks.
+ */
+export const highlightCode: Action<HTMLElement | undefined> = (
+  node: HTMLElement | undefined
+) => {
+  if (node) {
+    highlightContainerElement(node);
+  }
+};
+
+const highlightContainerElement = async (element: Element) => {
+  const prism = await getPrismModule();
+  prism.highlightAllUnder(element);
+};

--- a/packages/core/src/lib/highlight-code/highlight-code.ts
+++ b/packages/core/src/lib/highlight-code/highlight-code.ts
@@ -3,7 +3,22 @@ import { getPrismModule } from './prism';
 
 /**
  * Highlight code in any child `<pre><code /></pre>` blocks.
- * Elements should be styled according to Prism's expected HTML structure
+ * Elements should be styled according to Prism's expected HTML structure.
+ * highlighting only runs on mount of the element, so the element using the action should be a keyed element to force re-highlighting on updates.
+ *
+ * Usage example:
+ * ```svelte
+ * <script>
+ *   import { highlightCode } from '@viamrobotics/prime-core';
+ *   export let code: string;
+ * </script>
+ *
+ * {#key code}
+ *   <div use:highlightCode>
+ *     <pre><code class="language-javascript">{code}</code></pre>
+ *   </div>
+ * {/key}
+ * ```
  *
  * @param node - The node to highlight.
  */

--- a/packages/core/src/lib/highlight-code/index.ts
+++ b/packages/core/src/lib/highlight-code/index.ts
@@ -1,0 +1,1 @@
+export { highlightCode } from './highlight-code';

--- a/packages/core/src/lib/highlight-code/prism.ts
+++ b/packages/core/src/lib/highlight-code/prism.ts
@@ -17,7 +17,7 @@ import './viam-prism-theme.css';
 import 'prismjs/plugins/autoloader/prism-autoloader';
 const grammarsPath = `https://cdnjs.cloudflare.com/ajax/libs/prism/${PrismPackage.version}/components/`;
 
-export const getPrismModule = (): typeof import('prismjs') => {
+export const getPrismModule = (): typeof Prism => {
   // Make sure the autoloader knows where to find our languages
   (Prism.plugins.autoloader as { languages_path: string }).languages_path =
     grammarsPath;

--- a/packages/core/src/lib/highlight-code/prism.ts
+++ b/packages/core/src/lib/highlight-code/prism.ts
@@ -4,7 +4,7 @@
 
 import PrismPackage from 'prismjs/package.json';
 import Prism from 'prismjs';
-import 'prism-themes/themes/prism-vs.min.css';
+import './viam-prism-theme.css';
 
 /**
  * We use the prism autoloader to handle loading in language grammar files. The
@@ -17,7 +17,7 @@ import 'prism-themes/themes/prism-vs.min.css';
 import 'prismjs/plugins/autoloader/prism-autoloader';
 const grammarsPath = `https://cdnjs.cloudflare.com/ajax/libs/prism/${PrismPackage.version}/components/`;
 
-export const getPrismModule = async (): Promise<typeof import('prismjs')> => {
+export const getPrismModule = (): typeof import('prismjs') => {
   // Make sure the autoloader knows where to find our languages
   (Prism.plugins.autoloader as { languages_path: string }).languages_path =
     grammarsPath;

--- a/packages/core/src/lib/highlight-code/prism.ts
+++ b/packages/core/src/lib/highlight-code/prism.ts
@@ -1,0 +1,25 @@
+/**
+ * Wrapper module for Prism.js
+ */
+
+import PrismPackage from 'prismjs/package.json';
+import Prism from 'prismjs';
+import 'prism-themes/themes/prism-vs.min.css';
+
+/**
+ * We use the prism autoloader to handle loading in language grammar files. The
+ * default path for the grammar files is a CDN link so we don't have to include
+ * grammar files in our bundle. If you prefer to point to your own grammars and
+ * bypass the CDN, define the path to those files.
+ *
+ * See: https://prismjs.com/plugins/autoloader/
+ */
+import 'prismjs/plugins/autoloader/prism-autoloader';
+const grammarsPath = `https://cdnjs.cloudflare.com/ajax/libs/prism/${PrismPackage.version}/components/`;
+
+export const getPrismModule = async (): Promise<typeof import('prismjs')> => {
+  // Make sure the autoloader knows where to find our languages
+  (Prism.plugins.autoloader as { languages_path: string }).languages_path =
+    grammarsPath;
+  return Prism;
+};

--- a/packages/core/src/lib/highlight-code/viam-prism-theme.css
+++ b/packages/core/src/lib/highlight-code/viam-prism-theme.css
@@ -1,0 +1,17 @@
+@import 'prism-themes/themes/prism-vs.min.css';
+
+pre[class*='language-'],
+pre[class*='language-'] > code[class*='language-'] {
+  margin: 0;
+  border: none;
+  background: inherit;
+}
+
+pre[class*='language-'] {
+  padding: 0;
+}
+
+pre[class*='language-'] > code[class*='language-'] {
+  font-family: 'Roboto Mono Variable', 'Roboto Mono', ui-monospace, monospace;
+  font-size: 1em;
+}

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -80,3 +80,4 @@ export * from './keyboard';
 export { useTimeout } from './use-timeout';
 export { uniqueId } from './unique-id';
 export { default as VectorInput } from './vector-input.svelte';
+export { highlightCode } from './highlight-code';

--- a/packages/core/src/lib/modal.svelte
+++ b/packages/core/src/lib/modal.svelte
@@ -42,7 +42,7 @@ Creates a modal overlay.
 
 <script lang="ts">
 import cx from 'classnames';
-import { createEventDispatcher, onDestroy } from 'svelte';
+import { createEventDispatcher, onMount } from 'svelte';
 import IconButton from './button/icon-button.svelte';
 import { clickOutside } from '$lib';
 
@@ -73,10 +73,10 @@ $: if (typeof document !== 'undefined') {
   document.body.classList.toggle('overflow-hidden', isOpen);
 }
 
-onDestroy(() => {
-  if (typeof document !== 'undefined') {
+onMount(() => {
+  return () => {
     document.body.classList.remove('overflow-hidden');
-  }
+  };
 });
 </script>
 

--- a/packages/core/src/lib/modal.svelte
+++ b/packages/core/src/lib/modal.svelte
@@ -74,7 +74,9 @@ $: if (typeof document !== 'undefined') {
 }
 
 onDestroy(() => {
-  document.body.classList.remove('overflow-hidden');
+  if (typeof document !== 'undefined') {
+    document.body.classList.remove('overflow-hidden');
+  }
 });
 </script>
 

--- a/packages/core/src/routes/+page.svelte
+++ b/packages/core/src/routes/+page.svelte
@@ -702,7 +702,6 @@ const onHoverDelayMsInput = (event: Event) => {
   <CodeSnippet
     language="cpp"
     code={cppSnippet}
-    dependencies={['c']}
   />
 
   <h2 class="text-lg text-subtle-1">Dart</h2>

--- a/packages/storybook/src/stories/code-snippet.stories.svelte
+++ b/packages/storybook/src/stories/code-snippet.stories.svelte
@@ -124,7 +124,6 @@ log_hello_world()
 <Story name="CPlusPlus">
   <CodeSnippet
     language="cpp"
-    dependencies={['c']}
     code={`
 #include <iostream>
 


### PR DESCRIPTION
@ehhong and I noodling on Prism stuff

---
### Overview
Creating a Svelte action to handle code highlighting with Prism to modularize Prism logic and reuse logic between markdown component (in app) and code snippet element (in Prime).