### PR TITLE
subtask: fixing the literal-type constraint in the `message` prop for `Input` component

### DIFF
--- a/packages/legacy/src/elements/input/input.svelte
+++ b/packages/legacy/src/elements/input/input.svelte
@@ -32,7 +32,7 @@ export let max = '+Infinity';
 export let labelposition: LabelPosition = 'top';
 export let tooltip = '';
 export let state: 'info' | 'warn' | 'error' | 'success' | '' = 'info';
-export let message: '';
+export let message = '';
 export let incrementor: 'buttons' | 'slider' | 'none' = 'none';
 
 // https://github.com/sveltejs/svelte/issues/7596


### PR DESCRIPTION
### Context

working on [APP-6609](https://viam.atlassian.net/browse/APP-6609) of removing restricted text input across App and instead of the toggle to show the error message, we want to show the error message below the Input. see comment thread [here](https://github.com/viamrobotics/app/pull/7201#issuecomment-2569612209). While working on this, I ran into errors due to the `message` prop in the `Input` component being restricted to an empty string. This fix should ensure that validation errors are displayed as intended in the UI

### Changes
updated `export let message` to allow dynamic error message strings instead of being constrained to an empty literal type.

[APP-6609]: https://viam.atlassian.net/browse/APP-6609?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ