### PR TITLE
DATA-3601 Add code colors

### DIFF
--- a/packages/core/theme.ts
+++ b/packages/core/theme.ts
@@ -20,6 +20,14 @@ export const theme = {
       'subtle-2': '#7a7c80',
       disabled: '#9c9ca4',
       link: '#0066cc',
+
+      // Code colors
+      'code-boolean': '#201293',
+      'code-line-number': '#4b758d',
+      'code-null': '#708',
+      'code-number': '#2f6447',
+      'code-property-keys': '#000000',
+      'code-string': '#9c251d',
     },
     borderColor: {
       light: '#e4e4e6',

--- a/packages/core/theme.ts
+++ b/packages/core/theme.ts
@@ -26,7 +26,7 @@ export const theme = {
       'code-line-number': '#4b758d',
       'code-null': '#708',
       'code-number': '#2f6447',
-      'code-property-keys': '#000000',
+      'code-property-keys': '#000',
       'code-string': '#9c251d',
     },
     borderColor: {


### PR DESCRIPTION
Add colors to our theme for syntax highlighting so that we have something to use in situations where we are not using codemirror but want it to be visually consistent.