### PR TITLE
Feat: export icon path data for direct usage in non-Svelte UIs

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@viamrobotics/prime-core",
-  "version": "0.0.173",
+  "version": "0.0.174",
   "repository": {
     "type": "git",
     "url": "https://github.com/viamrobotics/prime.git",

--- a/packages/core/src/lib/icon/icon.svelte
+++ b/packages/core/src/lib/icon/icon.svelte
@@ -30,7 +30,7 @@ const sizes: Record<Size, string> = {
 
 <script lang="ts">
 import cx from 'classnames';
-import { paths, type IconName, type CustomIcon } from './icons';
+import { IconPathsByName, type IconName, type CustomIcon } from './icons';
 
 /** The name of the icon. */
 export let name: IconName;
@@ -45,7 +45,7 @@ export { extraClasses as cx };
 let allPaths: CustomIcon[] = [];
 
 $: {
-  const pathValue = paths[name];
+  const pathValue = IconPathsByName[name];
 
   if (typeof pathValue === 'string') {
     allPaths = [{ path: pathValue }];

--- a/packages/core/src/lib/icon/icons.ts
+++ b/packages/core/src/lib/icon/icons.ts
@@ -1,19 +1,19 @@
 import * as MDI from '@mdi/js';
 
-type Path = string;
+export type SimpleIconPath = string;
 
 export interface CustomIcon {
   path: string;
   opacity?: number | undefined;
 }
 
-export type IconPath = Path | CustomIcon[];
+export type IconPath = SimpleIconPath | CustomIcon[];
 
 /**
  * Keys should match MDI name
  * e.g. 'account-multiple' for MDI.mdiAccountMultiple
  */
-export const paths = {
+export const IconPathsByName = {
   'account-group-outline': MDI.mdiAccountGroupOutline,
   'account-multiple': MDI.mdiAccountMultiple,
   'alert-circle-outline': MDI.mdiAlertCircleOutline,
@@ -179,9 +179,9 @@ export const paths = {
   'view-dashboard-outline': MDI.mdiViewDashboardOutline,
   webhook: MDI.mdiWebhook,
   windows: MDI.mdiMicrosoftWindows,
-} as const;
+} satisfies Record<string, IconPath>;
 
 /**
  * The possible icon names that can be rendered. This is good for typing props.
  */
-export type IconName = keyof typeof paths;
+export type IconName = keyof typeof IconPathsByName;

--- a/packages/core/src/lib/icon/index.ts
+++ b/packages/core/src/lib/icon/index.ts
@@ -1,2 +1,8 @@
 export { default as Icon } from './icon.svelte';
-export type { IconName } from './icons';
+export {
+  IconPathsByName,
+  type IconName,
+  type IconPath,
+  type SimpleIconPath,
+  type CustomIcon,
+} from './icons';


### PR DESCRIPTION
After chatting in dev jam and reviewing a draft PR, it looks like exposing this path data directly will be useful for markdown-based UIs in the app